### PR TITLE
Add Grid REST API link to doc left-nav TOC

### DIFF
--- a/_includes/0.1/left_sidebar.html
+++ b/_includes/0.1/left_sidebar.html
@@ -33,7 +33,8 @@
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Reference Guides</div>
-        <a href="{% link docs/0.1/cli_references.md %}">CLI Command Reference</a>
-        <a href="https://docs.rs/crate/grid-sdk/0.1.0">Grid Rust SDK Reference</a>
+        <a href="{% link docs/0.1/cli_references.md %}">Grid CLIs</a>
+        <a href="{% link docs/0.1/references/api/index.md %}">Grid REST API</a>
+        <a href="https://docs.rs/crate/grid-sdk/0.1.0">Grid Rust SDK</a>
     </div>
 </div>

--- a/docs/0.1/references/api/index.md
+++ b/docs/0.1/references/api/index.md
@@ -8,7 +8,7 @@
 
 This API defines the endpoints for the Grid daemon, `griddd`. These
 endpoints allow external applications to access Grid functionality such as
-submitting batches to a Sawtooth Validator, getting a list of Schemas or
+submitting batches to a Sawtooth validator, getting a list of schemas or
 fetching an agent from Pike.
 
 * [Grid REST API Reference](/docs/0.1/api/)


### PR DESCRIPTION
The TOC link points to the existing "REST API Reference" landing page (this PR fixes two typos on that page).

Signed-off-by: Anne Chenette <chenette@bitwise.io>