### PR TITLE
Fix issues in CLI reference (grid usage)

### DIFF
--- a/docs/0.1/cli_references.md
+++ b/docs/0.1/cli_references.md
@@ -82,23 +82,6 @@ ARGS:
 Update an agent via the Pike smart contract.
 
 ```
-Update or create agent
-
-USAGE:
-    grid agent [FLAGS] <SUBCOMMAND>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-SUBCOMMANDS:
-    create    Create an agent
-    help      Prints this message or the help of the given subcommand(s)
-    update    Update an agent
-goldstone:debug rbanks$ ./grid agent update -h
-grid-agent-update
 Update an agent
 
 USAGE:

--- a/docs/0.1/cli_references.md
+++ b/docs/0.1/cli_references.md
@@ -21,9 +21,9 @@ or `--help` option.
 
 ## grid
 
-```
-Command line for Hyperledger Grid
+Command-line interface for Hyperledger Grid.
 
+```
 USAGE:
     grid [FLAGS] [OPTIONS] [SUBCOMMAND]
 
@@ -52,7 +52,7 @@ SUBCOMMANDS:
 
 ### grid agent create
 
-Create a pike agent via the Pike smart contract.
+Create an agent via the Pike smart contract.
 
 ```
 USAGE:
@@ -102,7 +102,7 @@ ARGS:
 
 ### grid database migrate
 
-Run database migrations to create and apply updates to the grid database tables.
+Run database migrations to create and apply updates to the Grid database tables.
 
 ```
 USAGE:
@@ -120,7 +120,7 @@ OPTIONS:
 
 ### grid keygen
 
-Generates keys with which the user can sign transactions and batches.
+Generate keys with which the user can sign transactions and batches.
 
 ```
 USAGE:
@@ -404,7 +404,6 @@ FLAGS:
 ARGS:
     <name>    Name of schema
 ```
-
 
 ### grid schema list
 

--- a/docs/0.1/cli_references.md
+++ b/docs/0.1/cli_references.md
@@ -235,6 +235,59 @@ ARGS:
     <path>    Path to yaml file containing a list of products
 ```
 
+### grid product delete
+
+Delete an existing product.
+
+```
+USAGE:
+    grid product delete [FLAGS] <product_id> <product_type>
+
+FLAGS:
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+
+ARGS:
+    <product_id>      Unique ID for a product
+    <product_type>    Type of product (e.g. GS1
+
+```
+
+### grid product list
+
+List all products available.
+
+```
+USAGE:
+    grid product list [FLAGS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+```
+
+### grid product show
+
+Show details for a given product.
+
+```
+USAGE:
+    grid product show [FLAGS] <product_id>
+
+FLAGS:
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+
+ARGS:
+    <product_id>    ID of product
+```
+
 ### grid product update
 
 Update an existing product.
@@ -294,59 +347,6 @@ ARGS:
     <path>    Path to yaml file containing a list of products
 ```
 
-### grid product delete
-
-Delete an existing product.
-
-```
-USAGE:
-    grid product delete [FLAGS] <product_id> <product_type>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-ARGS:
-    <product_id>      Unique ID for a product
-    <product_type>    Type of product (e.g. GS1
-
-```
-
-### grid product show
-
-Show details for a given product.
-
-```
-USAGE:
-    grid product show [FLAGS] <product_id>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-ARGS:
-    <product_id>    ID of product
-```
-
-### grid product list
-
-List all products available.
-
-```
-USAGE:
-    grid product list [FLAGS]
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-```
-
 ### grid schema create
 
 Create a schema definition via the Schema smart contract.
@@ -367,24 +367,19 @@ ARGS:
     <path>    Path to yaml file containing a list of schema definitions
 ```
 
-### grid schema update
+### grid schema list
 
-Update an existing schema definition via the Schema smart contract.
-This command requires a YAML file that specifies the schema fields to be
-updated.
+List all available schemas.
 
 ```
 USAGE:
-    grid schema update [FLAGS] <path>
+    grid schema list [FLAGS]
 
 FLAGS:
     -h, --help       Prints help information
     -q, --quiet      Do not display output
     -V, --version    Prints version information
     -v               Log verbosely
-
-ARGS:
-    <path>    Path to yaml file containing a list of schema definitions
 ```
 
 ### grid schema show
@@ -405,17 +400,22 @@ ARGS:
     <name>    Name of schema
 ```
 
-### grid schema list
+### grid schema update
 
-List all available schemas.
+Update an existing schema definition via the Schema smart contract.
+This command requires a YAML file that specifies the schema fields to be
+updated.
 
 ```
 USAGE:
-    grid schema list [FLAGS]
+    grid schema update [FLAGS] <path>
 
 FLAGS:
     -h, --help       Prints help information
     -q, --quiet      Do not display output
     -V, --version    Prints version information
     -v               Log verbosely
+
+ARGS:
+    <path>    Path to yaml file containing a list of schema definitions
 ```

--- a/docs/0.1/cli_references.md
+++ b/docs/0.1/cli_references.md
@@ -188,36 +188,38 @@ ARGS:
 
 ### grid product create
 
-Create a new product via the Schemas smart contract. Below is a sample YAML
-file that is used to describe a product.
+Create a new product via the Schema smart contract.
 
-```
-- product_type: "GS1"
-  product_id: "762111177704"
-  owner: "314156"
-  properties:
-    - name: "length"
-      data_type: "NUMBER"
-      number_value: 8
-    - name: "width"
-      data_type: "NUMBER"
-      number_value: 11
-    - name: "depth"
-      data_type: "NUMBER"
-      number_value: 1
-- product_type: "GS1"
-  product_id: "881334009880"
-  owner: "314156"
-  properties:
-    - name: "price"
-      data_type: "NUMBER"
-      number_value: 8
-    - name: "height"
-      data_type: "NUMBER"
-      number_value: 11
-```
+* **Note**: This command requires a YAML file that describes the product, as
+  shown in the following example:
 
-CLI help output
+  ```
+    - product_type: "GS1"
+      product_id: "762111177704"
+      owner: "314156"
+      properties:
+        - name: "length"
+          data_type: "NUMBER"
+          number_value: 8
+        - name: "width"
+          data_type: "NUMBER"
+          number_value: 11
+        - name: "depth"
+          data_type: "NUMBER"
+          number_value: 1
+    - product_type: "GS1"
+      product_id: "881334009880"
+      owner: "314156"
+      properties:
+        - name: "price"
+          data_type: "NUMBER"
+          number_value: 8
+        - name: "height"
+          data_type: "NUMBER"
+          number_value: 11
+  ```
+
+This command has the following syntax:
 
 ```
 USAGE:
@@ -235,34 +237,36 @@ ARGS:
 
 ### grid product update
 
-Update an existing product. Below is a sample YAML file used to specify the
-fields that are to be updated.
+Update an existing product.
 
-```
-- product_type: "GS1"
-  product_id: "762111177704"
-  properties:
-    - name: "length"
-      data_type: "NUMBER"
-      number_value: 88
-    - name: "width"
-      data_type: "NUMBER"
-      number_value: 111
-    - name: "depth"
-      data_type: "NUMBER"
-      number_value: 11
-- product_type: "GS1"
-  product_id: "881334009880"
-  properties:
-    - name: "price"
-      data_type: "NUMBER"
-      number_value: 88
-    - name: "height"
-      data_type: "NUMBER"
-      number_value: 111
-```
+* **Note**: This command requires a YAML file that describes the
+  product, as shown in the following example.
 
-CLI help output
+  ```
+    - product_type: "GS1"
+      product_id: "762111177704"
+      properties:
+        - name: "length"
+          data_type: "NUMBER"
+          number_value: 88
+        - name: "width"
+          data_type: "NUMBER"
+          number_value: 111
+        - name: "depth"
+          data_type: "NUMBER"
+          number_value: 11
+    - product_type: "GS1"
+      product_id: "881334009880"
+      properties:
+        - name: "price"
+          data_type: "NUMBER"
+          number_value: 88
+        - name: "height"
+          data_type: "NUMBER"
+          number_value: 111
+  ```
+
+This command has the following syntax:
 
 ```
 USAGE:
@@ -346,6 +350,8 @@ FLAGS:
 ### grid schema create
 
 Create a schema definition via the Schema smart contract.
+This command requires a YAML file that defines the schema.
+
 
 ```
 USAGE:
@@ -364,6 +370,8 @@ ARGS:
 ### grid schema update
 
 Update an existing schema definition via the Schema smart contract.
+This command requires a YAML file that specifies the schema fields to be
+updated.
 
 ```
 USAGE:

--- a/docs/0.1/cli_references.md
+++ b/docs/0.1/cli_references.md
@@ -55,8 +55,6 @@ SUBCOMMANDS:
 Create a pike agent via the Pike smart contract.
 
 ```
-Create an agent
-
 USAGE:
     grid agent create [FLAGS] [OPTIONS] <org_id> <public_key> --active --inactive
 
@@ -82,8 +80,6 @@ ARGS:
 Update an agent via the Pike smart contract.
 
 ```
-Update an agent
-
 USAGE:
     grid agent update [FLAGS] [OPTIONS] <org_id> <public_key> --active --inactive
 
@@ -109,8 +105,6 @@ ARGS:
 Run database migrations to create and apply updates to the grid database tables.
 
 ```
-Run database migrations
-
 USAGE:
     grid database migrate [FLAGS] [OPTIONS]
 
@@ -129,8 +123,6 @@ OPTIONS:
 Generates keys with which the user can sign transactions and batches.
 
 ```
-Generates keys with which the user can sign transactions and batches.
-
 USAGE:
     grid keygen [FLAGS] [OPTIONS] [key_name]
 
@@ -153,8 +145,6 @@ ARGS:
 Create a new organization using the Pike smart contract.
 
 ```
-Create an organization
-
 USAGE:
     grid organization create [FLAGS] [OPTIONS] <org_id> <name> [--] [address]
 
@@ -178,8 +168,6 @@ ARGS:
 Update an existing organization using the Pike smart contract.
 
 ```
-Update an organization
-
 USAGE:
     grid organization update [FLAGS] [OPTIONS] <org_id> <name> [--] [address]
 
@@ -232,8 +220,6 @@ file that is used to describe a product.
 CLI help output
 
 ```
-Create products from a yaml file
-
 USAGE:
     grid product create [FLAGS] <path>
 
@@ -279,8 +265,6 @@ fields that are to be updated.
 CLI help output
 
 ```
-Update products from a yaml file
-
 USAGE:
     grid product update [FLAGS] <path>
 
@@ -311,8 +295,6 @@ ARGS:
 Delete an existing product.
 
 ```
-Delete a product
-
 USAGE:
     grid product delete [FLAGS] <product_id> <product_type>
 
@@ -333,8 +315,6 @@ ARGS:
 Show details for a given product.
 
 ```
-Show product specified by ID argument
-
 USAGE:
     grid product show [FLAGS] <product_id>
 
@@ -353,8 +333,6 @@ ARGS:
 List all products available.
 
 ```
-List currently defined products
-
 USAGE:
     grid product list [FLAGS]
 
@@ -370,8 +348,6 @@ FLAGS:
 Create a schema definition via the Schema smart contract.
 
 ```
-Create schemas from a yaml file
-
 USAGE:
     grid schema create [FLAGS] <path>
 
@@ -390,8 +366,6 @@ ARGS:
 Update an existing schema definition via the Schema smart contract.
 
 ```
-Update schemas from a yaml file
-
 USAGE:
     grid schema update [FLAGS] <path>
 
@@ -410,8 +384,6 @@ ARGS:
 Show details for a specific schema.
 
 ```
-Show schema specified by name argument
-
 USAGE:
     grid schema show [FLAGS] <name>
 
@@ -431,8 +403,6 @@ ARGS:
 List all available schemas.
 
 ```
-List currently defined schemas
-
 USAGE:
     grid schema list [FLAGS]
 


### PR DESCRIPTION
- Remove "grid agent" usage (and copy pasta) from the "grid agent update" block

- Remove duplicate descriptions from all usage blocks (the content is in the intro sentence)

- Clarify notes for product & schema create/update: Move note to new line and indent to make skimming easier

- Fix typos, formatting, and capitalization

- Correct alphabetic order of subcommands