### PR TITLE
Add rewrite.conf for apache rewrite rules

### DIFF
--- a/apache/rewrite.conf
+++ b/apache/rewrite.conf
@@ -1,0 +1,6 @@
+LoadModule rewrite_module modules/mod_rewrite.so
+RewriteEngine on
+
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^/(.*).md$ /$1.html [NC,L,R]

--- a/ci/website.dockerfile
+++ b/ci/website.dockerfile
@@ -59,11 +59,14 @@ FROM httpd:2.4
 COPY --from=redoc /index_0.1.html /usr/local/apache2/htdocs/docs/0.1/api/index.html
 COPY --from=jekyll /tmp/ /usr/local/apache2/htdocs/
 COPY --from=git /commit-hash /commit-hash
+COPY apache/rewrite.conf /usr/local/apache2/conf/rewrite.conf
 
 RUN echo "\
 \n\
 ServerName grid.hyperledger.org\n\
-ErrorDocument 404 /404.html\
+ErrorDocument 404 /404.html\n\
+\n\
+Include /usr/local/apache2/conf/rewrite.conf\n\
 \n\
 " >>/usr/local/apache2/conf/httpd.conf
 

--- a/docker/grid-docs-apache
+++ b/docker/grid-docs-apache
@@ -14,6 +14,8 @@
 
 FROM httpd:2.4
 
+COPY apache/rewrite.conf /usr/local/apache2/conf/rewrite.conf
+
 RUN echo "\
 \n\
 ServerName grid-docs-apache\n\
@@ -21,15 +23,11 @@ AddDefaultCharset utf-8\n\
 LoadModule proxy_module modules/mod_proxy.so\n\
 LoadModule proxy_http_module modules/mod_proxy_http.so\n\
 LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so\n\
-LoadModule rewrite_module modules/mod_rewrite.so\n\
 ProxyPass /docs/0.1/api/ http://grid-docs-redoc-0-1:4001/\n\
 ProxyPassReverse /docs/0.1/api/ http://grid-docs-redoc-0-1:4001/\n\
 ProxyPass / http://grid-docs-jekyll:4000/\n\
 ProxyPassReverse / http://grid-docs-jekyll:4000/\n\
-RewriteEngine on\n\
-RewriteCond %{REQUEST_FILENAME} !-d\n\
-RewriteCond %{REQUEST_FILENAME} !-f\n\
-RewriteRule ^/(.*).md$ /\$1.html [NC,L,R]\n\
+Include /usr/local/apache2/conf/rewrite.conf\n\
 \n\
 " >>/usr/local/apache2/conf/httpd.conf
 


### PR DESCRIPTION
Moves management of rewrite rules out of Dockerfiles into a single file
shared by the development image and the deployable website image.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>