### PR TITLE
Add index.md in grid/nightly/master redirect dir

### DIFF
--- a/docs/grid/nightly/master/index.md
+++ b/docs/grid/nightly/master/index.md
@@ -1,0 +1,9 @@
+---
+redirect_to: /docs/
+---
+
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->


### PR DESCRIPTION
In case of old bookmarks to the Grid docs source in the grid repo, add an index.md file that redirects to the doc landing page for the Grid docs.

Signed-off-by: Anne Chenette <chenette@bitwise.io>