### PR TITLE
New For Administrators section in doc contents

### DIFF
--- a/_includes/0.1/left_sidebar.html
+++ b/_includes/0.1/left_sidebar.html
@@ -27,12 +27,15 @@
         <a href="{% link docs/0.1/grid_product.md %}">Product</a>
     </div>
     <div class="left-sidebar-group">
+        <div class="left-sidebar-header">For Administrators</div>
+        <a href="{% link docs/0.1/grid_on_splinter.md %}">Running Grid on Splinter</a>
+    </div>
+    <div class="left-sidebar-group">
         <div class="left-sidebar-header">For Developers</div>
         <a href="{% link docs/0.1/building_grid.md %}">Building Grid</a>
         <a href="{% link docs/0.1/grid_schema_family_specification.md %}">Schema Specification</a>
         <a href="{% link docs/0.1/grid_track_and_trace_family_specification.md %}">Track and Trace Specification</a>
         <a href="{% link docs/0.1/pike_transaction_family.md %}">Pike Specification</a>
-        <a href="{% link docs/0.1/grid_on_splinter.md %}">Running Grid on Splinter</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Reference Guides</div>


### PR DESCRIPTION
- Create a new "For Administrators" section" in the doc left-nav contents.

  This section will contain links to the new how-to procedures such as Creating a Circuit, Creating Organizations, and Creating Products, etc.

- Move "Running Grid on Splinter" to this section

NOTE: This PR is the required first step for splitting up the how-to procedures in "Running Grid on Splinter".  The subsequent PRs to add these procs as separate how-to topics will add links under "For Administrators". 

Signed-off-by: Anne Chenette <chenette@bitwise.io>