### PR TITLE
New "Using Grid Features" doc topic

### DIFF
--- a/_includes/0.1/left_sidebar.html
+++ b/_includes/0.1/left_sidebar.html
@@ -29,6 +29,7 @@
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">For Administrators</div>
         <a href="{% link docs/0.1/grid_on_splinter.md %}">Running Grid on Splinter</a>
+        <a href="{% link docs/0.1/using_grid_features.md %}">Using Grid Features</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">For Developers</div>

--- a/docs/0.1/using_grid_features.md
+++ b/docs/0.1/using_grid_features.md
@@ -1,0 +1,43 @@
+# Using Grid Features
+
+<!--
+  Copyright (c) 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+Most Grid features are designed to interact with Pike organizations and Schema
+definitions.
+
+For example, each product requires an owning organization, one or more agents
+that have permission to create and update the product, and a product schema
+that defines the structure and format of product properties.
+Likewise, each product schema must have an owning organization and an agent
+(or agents) with appropriate permissions.
+
+Follow these general steps when creating a new item such as a Grid Product.
+
+1. Create an organization with at least one agent that has the permissions to
+   create and manage the item.
+
+1. Create a product schema that defines the structure of product properties.
+
+1. Create a product that conforms to the property definitions in the product
+   schema.
+
+## Important Notes
+
+Before using Grid features such as Grid Product and Grid Location, the following
+prerequisites must be met.
+
+* Two or more nodes running Grid with the same backend distributed ledger
+  (either Splinter or Hyperledger Sawtooth). The following procedures describe
+  how to bring up a Grid node with each type of distributed ledger.
+
+    - [Running Grid on Splinter]({% link docs/0.1/grid_on_splinter.md %})
+    - Running Grid on Sawtooth (<i>available soon</i>)
+      <br><br>
+
+* For Grid on Splinter, these features require a **Splinter circuit** that
+  connects two or more nodes in a private network. Grid shares feature
+  information only with the member nodes on a specific circuit.

--- a/docs/0.1/using_grid_features.md
+++ b/docs/0.1/using_grid_features.md
@@ -15,15 +15,15 @@ that defines the structure and format of product properties.
 Likewise, each product schema must have an owning organization and an agent
 (or agents) with appropriate permissions.
 
-Follow these general steps when creating a new item such as a Grid Product.
+Follow these general steps when creating a new item:
 
 1. Create an organization with at least one agent that has the permissions to
    create and manage the item.
 
-1. Create a product schema that defines the structure of product properties.
+1. Create a schema that defines the structure of the item's properties.
 
-1. Create a product that conforms to the property definitions in the product
-   schema.
+1. Create an item (such as a product) that conforms to the property definitions
+   in the item's schema.
 
 ## Important Notes
 


### PR DESCRIPTION
This new topic summarizes the recommended order of using Grid features, such as Grid Product (org/agents first, then schema, then product). It also lists the requirements for using Grid features (2+ grid nodes; connected by a circuit for Grid on Splinter) and links to the available topics for those procedures.

- As separate Grid how-to procedures are added, this topic will link to those procedures.
- Each separate topic will have a "Next Steps" section that links back to this topic. 

This approach isolates the impact of link changes when a new how-to procedure is added; only this file will need to be updated with the new link.

This PR also adds this new topic under "For Administrators" in the doc's left-nav table of contents.
