### PR TITLE
Initial CLI reference

### DIFF
--- a/docs/0.1/cli_references.md
+++ b/docs/0.1/cli_references.md
@@ -1,421 +1,86 @@
 # CLI Command Reference
 
 <!--
-  Copyright (c) 2019-2020 Cargill Incorporated
+  Copyright 2018-2020 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
   https://creativecommons.org/licenses/by/4.0/
 -->
 
-The Grid command-line interface (CLI) provides a set of commands to interact
-with Grid services.
-
-This chapter shows the available options and arguments for each command and
-subcommand. The synopsis for each command shows its parameters and their usage.
-
-* Optional parameters are shown in square brackets
-* Choices are shown in curly braces.
-* User-supplied values are shown in angle brackets.
-
-This usage information is also available on the command line by using the `-h`
-or `--help` option.
-
-## grid
-
-Command-line interface for Hyperledger Grid.
+## grid CLI
+The `grid` command-line interface (CLI) provides a set of commands to interact
+with Grid components.
 
-```
-USAGE:
-    grid [FLAGS] [OPTIONS] [SUBCOMMAND]
+[`grid`]({% link docs/0.1/references/cli/grid.1.md %})
+Command-line interface for Grid
 
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-OPTIONS:
-    -k <key>                         base name for private key file
-        --service-id <service_id>    The ID of the service the payload should be sent to; required if running on
-                                     Splinter. Format <circuit-id>::<service-id>
-        --url <url>                  URL for the REST API
-        --wait <wait>                How long to wait for transaction to be committed
-
-SUBCOMMANDS:
-    agent           Update or create agent
-    database        Manage Grid Daemon database
-    help            Prints this message or the help of the given subcommand(s)
-    keygen          Generates keys with which the user can sign transactions and batches.
-    organization    Update or create organization
-    product         Create, update, or delete products
-    schema          Update or create schemas
-```
+### Agent Management
+[`grid agent`]({% link docs/0.1/references/cli/grid-agent.1.md %})
+Provides functionality for managing Pike Agents
 
-### grid agent create
-
-Create an agent via the Pike smart contract.
-
-```
-USAGE:
-    grid agent create [FLAGS] [OPTIONS] <org_id> <public_key> --active --inactive
+[`grid agent create`]({% link docs/0.1/references/cli/grid-agent-create.1.md %})
+Create a Pike Agent for an Organization with a set of roles
 
-FLAGS:
-        --active      Set agent as active
-    -h, --help        Prints help information
-        --inactive    Set agent as inactive
-    -q, --quiet       Do not display output
-    -V, --version     Prints version information
-    -v                Log verbosely
+[`grid agent update`]({% link docs/0.1/references/cli/grid-agent-update.1.md %})
+Update an existing Pike Agent
 
-OPTIONS:
-        --metadata <metadata>...    Key-value pairs (format: <key>=<value>) in a comma-separated list
-        --role <role>...            Roles assigned to agent
+### Organization Management
+[`grid organization`]({% link docs/0.1/references/cli/grid-organization.1.md %})
+Provides functionality for managing Pike Organizations
 
-ARGS:
-    <org_id>        organization ID
-    <public_key>    public key
-```
+[`grid organization create`]({%
+link docs/0.1/references/cli/grid-organization-create.1.md %})
+Create a Pike Organization. Automatically creates an agent with the `admin` role
 
-### grid agent update
-
-Update an agent via the Pike smart contract.
+[`grid organization update`]({%
+link docs/0.1/references/cli/grid-organization-update.1.md %})
+Update a Pike Organization
 
-```
-USAGE:
-    grid agent update [FLAGS] [OPTIONS] <org_id> <public_key> --active --inactive
+### Schema Management
+[`grid schema`]({% link docs/0.1/references/cli/grid-schema.1.md %})
+Provides functionality for managing Grid schema
 
-FLAGS:
-        --active      Set agent as active
-    -h, --help        Prints help information
-        --inactive    Set agent as inactive
-    -q, --quiet       Do not display output
-    -V, --version     Prints version information
-    -v                Log verbosely
+[`grid schema create`]({% link docs/0.1/references/cli/grid-schema-create.1.md %})
+Create schemas from a YAML file
 
-OPTIONS:
-        --metadata <metadata>...    Key-value pairs (format: <key>=<value>) in a comma-separated list
-        --role <role>...            Roles assigned to agent
+[`grid schema update`]({% link docs/0.1/references/cli/grid-schema-update.1.md %})
+Update schemas from a YAML file
 
-ARGS:
-    <org_id>        organization ID
-    <public_key>    public key
-```
-
-### grid database migrate
-
-Run database migrations to create and apply updates to the Grid database tables.
-
-```
-USAGE:
-    grid database migrate [FLAGS] [OPTIONS]
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-OPTIONS:
-        --database-url <database_url>    URL for database
-```
-
-### grid keygen
-
-Generate keys with which the user can sign transactions and batches.
-
-```
-USAGE:
-    grid keygen [FLAGS] [OPTIONS] [key_name]
-
-FLAGS:
-        --force      Overwrite files if they exist
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-OPTIONS:
-    -d, --key_dir <key_dir>    Specify the directory for the key files
-
-ARGS:
-    <key_name>    Name of the key to create
-```
-
-### grid organization create
-
-Create a new organization using the Pike smart contract.
-
-```
-USAGE:
-    grid organization create [FLAGS] [OPTIONS] <org_id> <name> [--] [address]
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-OPTIONS:
-        --metadata <metadata>...    Key-value pairs (format: <key>=<value>) in a comma-separated list
-
-ARGS:
-    <org_id>     Unique ID for organization
-    <name>       Name of the organization
-    <address>    Physical address for organization
-```
-
-### grid organization update
-
-Update an existing organization using the Pike smart contract.
-
-```
-USAGE:
-    grid organization update [FLAGS] [OPTIONS] <org_id> <name> [--] [address]
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-OPTIONS:
-        --metadata <metadata>...    Key-value pairs (format: <key>=<value>) in a comma-separated list
-
-ARGS:
-    <org_id>     Unique ID for organization
-    <name>       Name of the organization
-    <address>    Physical address for organization
-```
-
-### grid product create
-
-Create a new product via the Schema smart contract.
-
-* **Note**: This command requires a YAML file that describes the product, as
-  shown in the following example:
-
-  ```
-    - product_type: "GS1"
-      product_id: "762111177704"
-      owner: "314156"
-      properties:
-        - name: "length"
-          data_type: "NUMBER"
-          number_value: 8
-        - name: "width"
-          data_type: "NUMBER"
-          number_value: 11
-        - name: "depth"
-          data_type: "NUMBER"
-          number_value: 1
-    - product_type: "GS1"
-      product_id: "881334009880"
-      owner: "314156"
-      properties:
-        - name: "price"
-          data_type: "NUMBER"
-          number_value: 8
-        - name: "height"
-          data_type: "NUMBER"
-          number_value: 11
-  ```
-
-This command has the following syntax:
-
-```
-USAGE:
-    grid product create [FLAGS] <path>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-ARGS:
-    <path>    Path to yaml file containing a list of products
-```
-
-### grid product delete
-
-Delete an existing product.
-
-```
-USAGE:
-    grid product delete [FLAGS] <product_id> <product_type>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-ARGS:
-    <product_id>      Unique ID for a product
-    <product_type>    Type of product (e.g. GS1
-
-```
-
-### grid product list
-
-List all products available.
-
-```
-USAGE:
-    grid product list [FLAGS]
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-```
-
-### grid product show
-
-Show details for a given product.
-
-```
-USAGE:
-    grid product show [FLAGS] <product_id>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-ARGS:
-    <product_id>    ID of product
-```
-
-### grid product update
-
-Update an existing product.
-
-* **Note**: This command requires a YAML file that describes the
-  product, as shown in the following example.
-
-  ```
-    - product_type: "GS1"
-      product_id: "762111177704"
-      properties:
-        - name: "length"
-          data_type: "NUMBER"
-          number_value: 88
-        - name: "width"
-          data_type: "NUMBER"
-          number_value: 111
-        - name: "depth"
-          data_type: "NUMBER"
-          number_value: 11
-    - product_type: "GS1"
-      product_id: "881334009880"
-      properties:
-        - name: "price"
-          data_type: "NUMBER"
-          number_value: 88
-        - name: "height"
-          data_type: "NUMBER"
-          number_value: 111
-  ```
-
-This command has the following syntax:
-
-```
-USAGE:
-    grid product update [FLAGS] <path>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-ARGS:
-    <path>    Path to yaml file containing a list of products
-
-USAGE:
-    grid product update [FLAGS] <path>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-ARGS:
-    <path>    Path to yaml file containing a list of products
-```
-
-### grid schema create
-
-Create a schema definition via the Schema smart contract.
-This command requires a YAML file that defines the schema.
-
-
-```
-USAGE:
-    grid schema create [FLAGS] <path>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-ARGS:
-    <path>    Path to yaml file containing a list of schema definitions
-```
-
-### grid schema list
-
-List all available schemas.
-
-```
-USAGE:
-    grid schema list [FLAGS]
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-```
-
-### grid schema show
-
-Show details for a specific schema.
-
-```
-USAGE:
-    grid schema show [FLAGS] <name>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-ARGS:
-    <name>    Name of schema
-```
-
-### grid schema update
-
-Update an existing schema definition via the Schema smart contract.
-This command requires a YAML file that specifies the schema fields to be
-updated.
-
-```
-USAGE:
-    grid schema update [FLAGS] <path>
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Do not display output
-    -V, --version    Prints version information
-    -v               Log verbosely
-
-ARGS:
-    <path>    Path to yaml file containing a list of schema definitions
-```
+[`grid schema list`]({% link docs/0.1/references/cli/grid-schema-list.1.md %})
+List currently defined schemas
+
+[`grid schema show`]({% link docs/0.1/references/cli/grid-schema-show.1.md %})
+Show schema specified by name argument
+
+### Database Management
+[`grid database`]({% link docs/0.1/references/cli/grid-database.1.md %})
+Manage Grid Daemon database
+
+[`grid database migrate`]({%
+link docs/0.1/references/cli/grid-database-migrate.1.md %})
+Run migrations on the Grid Daemon database
+
+### Generate Key Pairs
+[`grid keygen`]({% link docs/0.1/references/cli/grid-keygen.1.md %})
+Generates keys with which the user can sign transactions and batches
+
+### Product Management
+[`grid product`]({% link docs/0.1/references/cli/grid-product.1.md %})
+Provides functionality for managing product data
+
+[`grid product create`]({%
+link docs/0.1/references/cli/grid-product-create.1.md %})
+Create products from a YAML file or via command-line arguments
+
+[`grid product update`]({%
+link docs/0.1/references/cli/grid-product-update.1.md %})
+Update products from a YAML file or via command-line arguments
+
+[`grid product delete`]({%
+link docs/0.1/references/cli/grid-product-delete.1.md %})
+Delete a product
+
+[`grid product list`]({% link docs/0.1/references/cli/grid-product-list.1.md %})
+List all currently defined products
+
+[`grid product show`]({% link docs/0.1/references/cli/grid-product-show.1.md %})
+Show product specified by ID argument

--- a/docs/0.1/references/cli/grid-agent-create.1.md
+++ b/docs/0.1/references/cli/grid-agent-create.1.md
@@ -1,0 +1,27 @@
+% GRID-AGENT-CREATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+```
+USAGE:
+    grid agent create [FLAGS] [OPTIONS] <org_id> <public_key> --active --inactive
+
+FLAGS:
+        --active      Set agent as active
+    -h, --help        Prints help information
+        --inactive    Set agent as inactive
+    -q, --quiet       Do not display output
+    -V, --version     Prints version information
+    -v                Log verbosely
+
+OPTIONS:
+        --metadata <metadata>...    Key-value pairs (format: <key>=<value>) in a comma-separated list
+        --role <role>...            Roles assigned to agent
+
+ARGS:
+    <org_id>        organization ID
+    <public_key>    public key
+```

--- a/docs/0.1/references/cli/grid-agent-update.1.md
+++ b/docs/0.1/references/cli/grid-agent-update.1.md
@@ -1,0 +1,26 @@
+% GRID-AGENT-UPDATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+```
+USAGE:
+    grid agent update [FLAGS] [OPTIONS] <org_id> <public_key> --active --inactive
+
+FLAGS:
+        --active      Set agent as active
+    -h, --help        Prints help information
+        --inactive    Set agent as inactive
+    -q, --quiet       Do not display output
+    -V, --version     Prints version information
+    -v                Log verbosely
+
+OPTIONS:
+        --metadata <metadata>...    Key-value pairs (format: <key>=<value>) in a comma-separated list
+        --role <role>...            Roles assigned to agent
+
+ARGS:
+    <org_id>        organization ID
+```

--- a/docs/0.1/references/cli/grid-agent.1.md
+++ b/docs/0.1/references/cli/grid-agent.1.md
@@ -1,0 +1,11 @@
+% GRID-AGENT(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+USAGE
+====
+
+**grid agent** \[**FLAGS**\] <**SUBCOMMAND**>

--- a/docs/0.1/references/cli/grid-database-migrate.1.md
+++ b/docs/0.1/references/cli/grid-database-migrate.1.md
@@ -1,0 +1,20 @@
+% GRID-DATABASE-MIGRATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+```
+USAGE:
+    grid database migrate [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+
+OPTIONS:
+        --database-url <database_url>    URL for database
+```

--- a/docs/0.1/references/cli/grid-database.1.md
+++ b/docs/0.1/references/cli/grid-database.1.md
@@ -1,0 +1,11 @@
+% GRID-DATABASE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+USAGE
+====
+
+**grid database** \[**FLAGS**\] <**SUBCOMMAND**>

--- a/docs/0.1/references/cli/grid-keygen.1.md
+++ b/docs/0.1/references/cli/grid-keygen.1.md
@@ -1,0 +1,27 @@
+% GRID-KEYGEN(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+USAGE
+====
+
+```
+USAGE:
+    grid keygen [FLAGS] [OPTIONS] [key_name]
+
+FLAGS:
+        --force      Overwrite files if they exist
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+
+OPTIONS:
+    -d, --key_dir <key_dir>    Specify the directory for the key files
+
+ARGS:
+    <key_name>    Name of the key to create
+```

--- a/docs/0.1/references/cli/grid-organization-create.1.md
+++ b/docs/0.1/references/cli/grid-organization-create.1.md
@@ -1,0 +1,25 @@
+% GRID-ORGANIZATION-CREATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+```
+USAGE:
+    grid organization create [FLAGS] [OPTIONS] <org_id> <name> [--] [address]
+
+FLAGS:
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+
+OPTIONS:
+        --metadata <metadata>...    Key-value pairs (format: <key>=<value>) in a comma-separated list
+
+ARGS:
+    <org_id>     Unique ID for organization
+    <name>       Name of the organization
+    <address>    Physical address for organization
+```

--- a/docs/0.1/references/cli/grid-organization-update.1.md
+++ b/docs/0.1/references/cli/grid-organization-update.1.md
@@ -1,0 +1,25 @@
+% GRID-ORGANIZATION-UPDATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+```
+USAGE:
+    grid organization update [FLAGS] [OPTIONS] <org_id> <name> [--] [address]
+
+FLAGS:
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+
+OPTIONS:
+        --metadata <metadata>...    Key-value pairs (format: <key>=<value>) in a comma-separated list
+
+ARGS:
+    <org_id>     Unique ID for organization
+    <name>       Name of the organization
+    <address>    Physical address for organization
+```

--- a/docs/0.1/references/cli/grid-organization.1.md
+++ b/docs/0.1/references/cli/grid-organization.1.md
@@ -1,0 +1,11 @@
+% GRID-ORGANIZATION(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+USAGE
+====
+
+**grid organization** \[**FLAGS**\] <**SUBCOMMAND**>

--- a/docs/0.1/references/cli/grid-product-create.1.md
+++ b/docs/0.1/references/cli/grid-product-create.1.md
@@ -1,0 +1,122 @@
+% GRID-PRODUCT-CREATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product-create** — Create products from a YAML file
+
+SYNOPSIS
+========
+
+**grid product create** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+
+Create new products from a YAML file. This command requires the `--path` option to
+specify a path to a YAML file containing the list of products.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+OPTIONS
+=======
+
+`--path`
+: Path to a YAML file containing a list of products
+
+EXAMPLES
+========
+
+Products can be created by using the `create` command
+
+```
+$ grid product create \
+    --path products.yaml
+```
+
+Sample YAML file describing a list of products.
+
+```
+- product_namespace: "GS1"
+  product_id: "762111177704"
+  owner: "314156"
+  properties:
+    - name: "length"
+      data_type: "NUMBER"
+      number_value: 8
+    - name: "width"
+      data_type: "NUMBER"
+      number_value: 11
+    - name: "height"
+      data_type: "NUMBER"
+      number_value: 1
+- product_namespace: "GS1"
+  product_id: "881334009880"
+  owner: "314156"
+  properties:
+    - name: "length"
+      data_type: "NUMBER"
+      number_value: 8
+    - name: "width"
+      data_type: "NUMBER"
+      number_value: 11
+    - name: "height"
+      data_type: "NUMBER"
+      number_value: 11
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/docs/0.1/references/cli/grid-product-delete.1.md
+++ b/docs/0.1/references/cli/grid-product-delete.1.md
@@ -1,0 +1,94 @@
+% GRID-PRODUCT-DELETE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product-delete** — Delete an existing product
+
+SYNOPSIS
+========
+
+**grid product delete** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+
+Delete an existing product. This command requires the `--product_id` option
+to specify the unique identifier of the product that is to be deleted. The
+`--product_namespace` option must also be specified (e.g. GS1).
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+OPTIONS
+=======
+
+`--product_id`
+: Unique identifier for the product
+
+`--product_namespace`
+: Product namespace (e.g. `GS1`)
+
+EXAMPLES
+========
+
+Delete an existing product.
+
+```
+$ grid product delete --product_id 762111177704 --product_namespace GS1
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/docs/0.1/references/cli/grid-product-list.1.md
+++ b/docs/0.1/references/cli/grid-product-list.1.md
@@ -1,0 +1,99 @@
+% GRID-PRODUCT-LIST(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product-list** — List all products
+
+SYNOPSIS
+========
+
+**grid product list** \[**FLAGS**\]
+
+DESCRIPTION
+===========
+
+List all products in grid. If the `service_id` flag is specified, only
+products corresponding to that `service_id` will be shown.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+EXAMPLES
+========
+
+The command
+
+```
+$ grid product list
+```
+
+Will list all products and their properties
+
+```
+Product ID: 762111177704
+Product Namespace: GS1
+Owner: 314156
+Properties:
+    length: 8
+    width: 11
+    height: 1
+Product ID: 881334009880
+Product Namespace: GS1
+Owner: 314156
+Properties:
+    length: 8
+    width: 11
+    height: 11
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/docs/0.1/references/cli/grid-product-show.1.md
+++ b/docs/0.1/references/cli/grid-product-show.1.md
@@ -1,0 +1,99 @@
+% GRID-PRODUCT-SHOW(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product-show** — Show the details of a specific product
+
+SYNOPSIS
+========
+
+**grid product show** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+
+Show the complete details of a specific product. This command requires the
+`--product_id` option to specify the unique identifier for the product that
+is to be retrieved.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+OPTIONS
+=======
+
+`--product_id`
+: A unique identifier for product
+
+EXAMPLES
+========
+
+The command
+
+```
+$ grid product show --product_id 762111177704
+```
+
+Will show the details of the specified product
+
+```
+Product ID: 762111177704
+Product Namespace: GS1
+Owner: 314156
+Properties:
+    length: 8
+    width: 11
+    height: 1
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/docs/0.1/references/cli/grid-product-update.1.md
+++ b/docs/0.1/references/cli/grid-product-update.1.md
@@ -1,0 +1,122 @@
+% GRID-PRODUCT-UPDATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid-product-update** — Updates existing products
+
+SYNOPSIS
+========
+
+**grid product update** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+
+Updates existing products. This command requires the `--path` option
+to specify the path to a YAML file containing a list of products.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-k`, `--key`
+: Base name for private key file
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+OPTIONS
+=======
+
+`--path`
+: Path to a YAML file containing a list of products
+
+EXAMPLES
+========
+
+Products can be updated by using the `update` command
+
+```
+$ grid product update \
+    --path products.yaml
+```
+
+Sample YAML file describing products.
+
+```
+- product_namespace: "GS1"
+  product_id: "762111177704"
+  owner: "314156"
+  properties:
+    - name: "length"
+      data_type: "NUMBER"
+      number_value: 8
+    - name: "width"
+      data_type: "NUMBER"
+      number_value: 12
+    - name: "height"
+      data_type: "NUMBER"
+      number_value: 4
+- product_namespace: "GS1"
+  product_id: "881334009880"
+  owner: "314156"
+  properties:
+    - name: "length"
+      data_type: "NUMBER"
+      number_value: 8
+    - name: "width"
+      data_type: "NUMBER"
+      number_value: 12
+    - name: "height"
+      data_type: "NUMBER"
+      number_value: 12
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/

--- a/docs/0.1/references/cli/grid-product.1.md
+++ b/docs/0.1/references/cli/grid-product.1.md
@@ -1,0 +1,11 @@
+% GRID-KEYGEN(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+USAGE
+====
+
+**grid product** \[**FLAGS**\] <**SUBCOMMAND**>

--- a/docs/0.1/references/cli/grid-schema-create.1.md
+++ b/docs/0.1/references/cli/grid-schema-create.1.md
@@ -1,0 +1,20 @@
+% GRID-SCHEMA-CREATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+```
+USAGE:
+    grid schema create [FLAGS] <path>
+
+FLAGS:
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+
+ARGS:
+    <path>    Path to yaml file containing a list of schema definitions
+```

--- a/docs/0.1/references/cli/grid-schema-list.1.md
+++ b/docs/0.1/references/cli/grid-schema-list.1.md
@@ -1,0 +1,17 @@
+% GRID-SCHEMA-LIST(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+```
+USAGE:
+    grid schema list [FLAGS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+```

--- a/docs/0.1/references/cli/grid-schema-show.1.md
+++ b/docs/0.1/references/cli/grid-schema-show.1.md
@@ -1,0 +1,20 @@
+% GRID-SCHEMA-SHOW(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+```
+USAGE:
+    grid schema show [FLAGS] <name>
+
+FLAGS:
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+
+ARGS:
+    <name>    Name of schema
+```

--- a/docs/0.1/references/cli/grid-schema-update.1.md
+++ b/docs/0.1/references/cli/grid-schema-update.1.md
@@ -1,0 +1,20 @@
+% GRID-SCHEMA-UPDATE(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+```
+USAGE:
+    grid schema update [FLAGS] <path>
+
+FLAGS:
+    -h, --help       Prints help information
+    -q, --quiet      Do not display output
+    -V, --version    Prints version information
+    -v               Log verbosely
+
+ARGS:
+    <path>    Path to yaml file containing a list of schema definitions
+```

--- a/docs/0.1/references/cli/grid-schema.1.md
+++ b/docs/0.1/references/cli/grid-schema.1.md
@@ -1,0 +1,11 @@
+% GRID-SCHEMA(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+USAGE
+====
+
+**grid schema** \[**FLAGS**\] <**SUBCOMMAND**>

--- a/docs/0.1/references/cli/grid.1.md
+++ b/docs/0.1/references/cli/grid.1.md
@@ -1,0 +1,119 @@
+% GRID(1) Cargill, Incorporated | Grid Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**grid** — Command-line interface for Grid
+
+SYNOPSIS
+========
+
+**grid** \[**FLAGS**\] \[**OPTIONS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+
+The `grid` utility is the command-line interface for Grid.
+
+* Run `grid --help` to see the list of subcommands.
+
+* Run `grid *SUBCOMMAND* --help` to see information about a specific
+  subcommand (for example, `grid location create --help`).
+
+* To view the man page for a Grid subcommand, use the "dashed form" of the
+  name, where each space is replaced with a hyphen. For example, run
+  `man grid-location-create` to see the man page for `grid location create`.
+
+SUBCOMMANDS
+===========
+
+`admin`
+: Administrative commands for grid
+
+`agent`
+: Update or create an agent
+
+`database`
+: Manage Grid Daemon database
+
+`keygen`
+: Generate keys with which the user can sign transactions and batches
+
+`location`
+: Provides commands for creating, updating, and deleting locations
+
+`organization`
+: Update or create an organization
+
+`product`
+: Create, update or delete products
+
+`schema`
+: Update or create schemas
+
+FLAGS
+=====
+
+Most `grid` subcommands accept the following common flags:
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`--service-id`
+: The ID of the service the payload should be sent to; required if running on
+  Splinter. Format <circuit-id>::<service-id>
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output
+
+OPTIONS
+=======
+
+`-k`, `--key`
+: Base name for private key file
+
+`--url`
+: URL for the REST API
+
+`--wait`
+: How long to wait for transaction to be committed
+
+ENVIRONMENT VARIABLES
+=====================
+
+Many `grid` subcommands accept the following environment variable:
+
+**`GRID_DAEMON_ENDPOINT`**
+: Specifies the endpoint for the grid daemon (`gridd`)
+  if `-U` or `--url` is not used.
+
+**`GRID_DAEMON_KEY`**
+: Specifies key used to sign transactions if `k` or `--key`
+  is not used.
+
+**`GRID_SERVICE_ID`**
+: Specifies service ID if `--service-id` is not used
+
+SEE ALSO
+========
+| `grid-product-create(1)`
+| `grid-product-update(1)`
+| `grid-product-delete(1)`
+| `grid-product-show(1)`
+| `grid-product-list(1)`
+|
+| `grid(1)`
+|
+| Grid documentation: https://grid.hyperledger.org/docs/0.1/


### PR DESCRIPTION
Add the initial pass at the CLI reference. Currently only the `grid`
command and `grid product ...` subcommands have full man pages. The
other subcommands simple show the basic usage statement.

Signed-off-by: Davey Newhall <newhall@bitwise.io>