### PR TITLE
Fix typo after Building Grid link

### DIFF
--- a/_includes/0.1/left_sidebar.html
+++ b/_includes/0.1/left_sidebar.html
@@ -34,16 +34,16 @@
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">For Developers</div>
-        <a href="{% link docs/0.1/building_grid.md %}">Building Grid</a>og spec
+        <a href="{% link docs/0.1/building_grid.md %}">Building Grid</a>
         <a href="{% link docs/0.1/grid_on_splinter.md %}">Running Grid on Splinter</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Smart Contracts</div>
-        <a href="{% link docs/0.1/grid_location_smart_contract_specification.md %}">Location specification</a>
+        <a href="{% link docs/0.1/grid_location_smart_contract_specification.md %}">Location Specification</a>
         <a href="{% link docs/0.1/pike_smart_contract_specification.md %}">Pike Specification</a>
+        <a href="{% link docs/0.1/grid_product_catalog_smart_contract_specification.md %}">Product Catalog Specification</a>
         <a href="{% link docs/0.1/schema_smart_contract_specification.md %}">Schema Specification</a>
         <a href="{% link docs/0.1/grid_track_and_trace_smart_contract_specification.md %}">Track and Trace Specification</a>
-        <a href="{% link docs/0.1/grid_product_catalog_smart_contract_specification.md %}">Product Catalog Specification</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Reference Guides</div>


### PR DESCRIPTION
Also put the new Product Catalog spec in alphabetic order and capitalize the S in "Location Specification"

Moved the Product Catalog spec to the top of the list

Signed-off-by: Anne Chenette <chenette@bitwise.io>