### PR TITLE
Add new Creating Organizations procedure

### DIFF
--- a/_includes/0.1/left_sidebar.html
+++ b/_includes/0.1/left_sidebar.html
@@ -31,6 +31,7 @@
         <a href="{% link docs/0.1/grid_on_splinter.md %}">Running Grid on Splinter</a>
         <a href="{% link docs/0.1/creating_splinter_circuits.md %}">Creating Splinter Circuits</a>
         <a href="{% link docs/0.1/using_grid_features.md %}">Using Grid Features</a>
+        <a href="{% link docs/0.1/creating_organizations.md %}">Creating Organizations</a>
         <a href="{% link docs/0.1/creating_products.md %}">Creating Products</a>
     </div>
     <div class="left-sidebar-group">

--- a/docs/0.1/creating_organizations.md
+++ b/docs/0.1/creating_organizations.md
@@ -1,0 +1,236 @@
+# Creating Organizations
+
+<!--
+  Copyright (c) 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+This procedure describes how to create and manage Pike organizations and agents
+using Grid's command-line interface.
+
+Each Grid item such as a schema or product requires an owning organization and
+at least one active agent with permissions to create and update those Grid
+items.
+
+## Prerequisites
+
+* For Grid on Sawtooth:
+
+    - A working Grid node. This procedure includes verification steps on a
+      second Grid node, but all steps can be performed on a single node.
+      <br><br>
+
+* For Grid on Splinter:
+
+    - Two or more working Grid nodes. (See [Running Grid on
+      Splinter](grid_on_splinter.md) for the procedure to set up and run Grid
+      in Docker containers.) The examples in this procedure show two nodes,
+      `alpha-node-000` and `beta-node-000`, that are running in a Docker
+      environment.
+
+    - An approved Splinter circuit with two or more member nodes.
+      (See [Creating Splinter Circuits]({% link
+      docs/0.1/creating_splinter_circuits.md %}) for more information.)
+      This procedure assumes that there is a circuit with `alpha-node-000` and
+      `beta-node-000` as members.
+
+    - A fully qualified service ID for the scabbard service on this circuit, in
+      the format <code><i>CircuitID</i>::<i>ServiceString</i></code>.
+      (See [Determine the Service
+      ID]({% link docs/0.1/creating_splinter_circuits.md
+      %}#determine-the-service-id) for the commands to display this
+      information.) This procedure uses the example ID `01234-ABCDE::gsAA`.
+
+* The Grid daemon's endpoint (URL and port) on one or both nodes.
+  This procedure uses `https://localhost:8080`.
+
+## Important Notes
+
+The examples in this procedure use the node hostnames, container names, node
+IDs, and URLs that are defined in the example docker-compose file,
+`examples/splinter/docker-compose.yaml`. If you are not using this example
+environment, replace these items with the actual values for your nodes.
+
+## Procedure
+
+### Connect to a Grid Node
+
+1. Start a bash session in your node's `gridd` Docker container (such as
+   `gridd-alpha`). You will use this container to run Grid commands on the
+   node (for example, `alpha-node-000`).
+
+   ```
+   $ docker exec -it gridd-alpha bash
+   root@gridd-alpha:/#
+   ```
+
+### Generate Agent Keys
+
+{:start="2"}
+
+2. Generate a secp256k1 key pair for the organization's agent on the alpha node.
+   This key will be used to sign the Grid transactions that create organizations
+   and set agent permissions.
+
+   This example uses the base name `alpha-agent` to indicate that you will be
+   acting as your organization's agent to add products and other Grid items
+   from the alpha node.
+
+   ```
+   root@gridd-alpha:/# grid keygen alpha-agent
+   Writing /root/.grid/keys/alpha-agent.priv
+   Writing /root/.grid/keys/alpha-agent.pub
+   ```
+
+### Set Environment Variables
+
+Set the following Grid environment variables to simplify entering the
+`grid` commands in this procedure.
+
+{:start="3"}
+
+3. Set `GRID_DAEMON_KEY` to the base name of the agent's public/private key
+   files (such as `alpha-agent`). This environment variable replaces the
+   `-k` option on the `grid` command line.
+
+   Tip: If you're using this example docker-compose environment, this
+   variable is already defined for the `gridd-alpha` and `gridd-beta` containers.
+
+   ```
+   root@gridd-alpha:/# export GRID_DAEMON_KEY="alpha-agent"
+   ```
+
+   **Note**: Although this variable has "daemon" in the name, it should
+   reference the user key files in `$HOME/.grid/keys`, not the Grid daemon's key
+   files in `/etc/grid/keys`.
+
+1. Set `GRID_DAEMON_ENDPOINT` to the endpoint for the node's `gridd` container
+   (such as `https://localhost:8080`). This environment variable replaces the
+   `--url` option on the `grid` command line.
+
+   Tip: If you're using this example docker-compose environment, this variable
+   is already defined for the `gridd-alpha` and `gridd-beta` containers.
+
+   ```
+   root@gridd-alpha:/# export GRID_DAEMON_ENDPOINT="https://localhost:8080"
+   ```
+
+1. For Grid on Splinter: Set `GRID_SERVICE_ID` to the fully qualified service ID
+   for the scabbard service on this circuit (such as `01234-ABCDE::gsAA`).
+   This environment variable replaces the `--service_id` option on the `grid`
+   command line.
+
+   ```
+   root@gridd-alpha:/# export GRID_SERVICE_ID=01234-ABCDE::gsAA
+   ```
+
+### Create an Organization
+
+{:start="6"}
+
+6. Create a new organization by specifying a unique organization ID, the
+   organization's name and street address, and optional metadata (as key-value
+   strings).
+
+   This example uses the ID `314156`, the name `myorg`, an imaginary street
+   address, and GS1-specific metadata to note that the ID is a GS1 company
+   prefix.
+
+   ```
+   root@gridd-alpha:/# grid organization create \
+   314156 myorg '123 main street' \
+   --metadata gs1_company_prefixes=314156
+   ```
+
+   This command creates and submits a transaction to create a new Pike
+   organization with the data you supplied, as well as a new Pike agent
+   with the `admin` role and `active` status.
+
+   The transaction is signed with the agent's private key, as derived from the
+   base name specified by `GRID_DAEMON_KEY` (or with the `-k` option on the
+   command line). The agent's public key is used as the agent ID.
+
+   **Note**: This command doesn't display any output. Instead, check the log
+   messages (in the terminal window where you started the Grid Docker
+   environment) for the success or failure of this operation.
+
+### Set Agent Permissions
+
+A newly created agent does not have any permissions, which means the agent
+cannot make Grid-related changes on behalf of the organization. The following
+steps show how to set the appropriate permissions (also called "Pike roles")
+for products, schemas, and other Grid features.
+
+**Note**: An agent belongs to only one organization. All agent permissions apply
+only to this organization.
+
+{:start="7"}
+
+7. Verify that the agent's public key file exists in
+   `~/.grid/keys/alpha-agent.pub`. If not, you must specify contents of the
+   public key file in the next command.
+
+1. Set the appropriate permissions (also called "Pike roles") for the agent.
+   The following command requires the organization ID (such as `314156`) and the
+   agent's public key string.
+
+   This example allows the agent to create schemas and to create, update, and
+   delete products.
+
+   ```
+   root@gridd-alpha:/# grid agent update \
+   314156 $(cat ~/.grid/keys/alpha-agent.pub) \
+   --active \
+   --role can_create_schema \
+   --role can_create_product \
+   --role can_update_product \
+   --role can_delete_product \
+   --role admin
+   ```
+
+   **Note**: You must specify `--active` and `--role admin`, even though the
+   previous command automatically enabled these settings. The `grid` CLI
+   requires these options to ensure that these important settings are not
+   accidentally changed.
+
+### Display Organizations and Agents
+
+The Grid REST API provides the `/organization` and `/agent` endpoints to query
+the distributed ledger for organization and agent information.
+You can use `curl` to submit requests to the Grid REST API from the command
+line.
+
+The following examples show how to run these commands on your host system,
+because the `curl` command is not available by default in the `gridd` container
+in the example environment.
+
+1. In the Grid node's `gridd` container, display the fully qualified service ID
+   and copy it to use in the following `curl` commands.
+
+   ```
+   root@gridd-alpha:/# echo $GRID_SERVICE_ID
+   01234-ABCDE::gsAA
+   ```
+
+   **Note**: Because requests to the Grid REST API are handled by the scabbard
+   service on an existing circuit, a fully qualified service ID is required.
+
+1. Request the list of organizations (from a system with `curl` installed).
+
+   ```
+   $ echo curl https://localhost:8080/organization?service_id=01234-ABCDE::gsAA
+   ```
+
+1. Request the list of agents.
+
+   ```
+   $ echo curl http://localhost:8080/agent?service_id=01234-ABCDE::gsAA
+   ```
+
+## Next Steps
+
+Once you have an organization and one or more agents with schema and product
+permissions, you can define a product schema and create products. For more
+information, see [Using Grid
+Features]({% link docs/0.1/using_grid_features.md %}).

--- a/docs/0.1/grid_on_splinter.md
+++ b/docs/0.1/grid_on_splinter.md
@@ -70,25 +70,22 @@ For more information on Splinter circuits, see the
 
 ### Demonstrate Grid Smart Contract Functionality
 
-**Note:** To simplify this procedure, the example `docker-compose.yaml` file
-defines environment variables for the ``gridd-alpha`` and ``gridd-beta``
-containers. These variables define the Grid daemon's key file and endpoint,
-so you don't have to use the `-k` and `--url` options with the `grid` command in
-this section.
+You can use the Pike and Grid Product smart contracts to demonstrate Grid
+functionality by creating an organization and agent, then creating a product.
 
-The following environment variables apply only to this example. If you want to
-override these values, you can edit `docker-compose.yaml` to redefine the
-variables, or you can use the associated option with the `grid` commands in
-steps 3 through 10.
+* [Creating Organizations]({% link docs/0.1/creating_organizations.md %})
+  describes how to create an owning organization for Grid items (such as
+  products), and set the permissions for an agent who is
+  allowed to create and manage those items.
 
-- `GRID_DAEMON_KEY` defines the key file name for the Grid daemon, as generated
-   by the `docker-compose.yaml` file. Use `-k <keyfile>` to override this
-   variable on the command line.
+After creating an organization and agent, you can use the following steps to
+create an example product.
 
-- `GRID_DAEMON_ENDPOINT` defines the endpoint for the ``gridd-alpha`` or
-   ``gridd-beta`` container. Use `--url <endpoint>` to override this variable
-   on the command line.
-
+**Note**: The following `grid` commands require the `GRID_DAEMON_KEY` and
+`GRID_DAEMON_ENDPOINT` environment variables, as set by the example
+`docker-compose.yaml` file. If these variables are not set, or if you want to
+override the example values, use the `-k <keyfile>` and `--url <endpoint>`
+options on the command line.
 
 1. Start a bash session in the `gridd-alpha` Docker container.  You will use
    this container to run Grid commands on `alpha-node-000`.
@@ -98,15 +95,7 @@ steps 3 through 10.
    root@gridd-alpha:/#
    ```
 
-2. Generate a secp256k1 key pair for the alpha node. This key will be used to
-   sign Grid transactions.
-
-   `root@gridd-alpha:/# grid keygen alpha-agent`
-
-   This command generates two files, `alpha-agent.priv` and `alpha-agent.pub`,
-   in the `~/.grid/keys/` directory.
-
-3. Set an environment variable with the service ID. Use the circuit ID of the
+1. Set an environment variable with the service ID. Use the circuit ID of the
    circuit that was created above. The commands below will check this variable
    to determine which circuit and service the command should be run against. An
    alternative to using the environment variable is to pass the service ID via
@@ -116,33 +105,7 @@ steps 3 through 10.
    root@gridd-alpha:/# export GRID_SERVICE_ID=01234-ABCDE::gsAA
    ```
 
-4. Create a new organization, `myorg`.
-
-   ```
-   root@gridd-alpha:/# grid \
-   organization create 314156 myorg '123 main street' \
-    --metadata gs1_company_prefixes=314156
-   ```
-
-   This command creates and submits a transaction to create a new Pike
-   organization that is signed by the admin key. It also creates a new Pike
-   agent with the “admin” role for the new organization (this agent’s public key
-   is derived from the private key used to sign the transaction.) The service ID
-   includes the circuit name and the scabbard service name for the alpha node.
-
-5. Update the agent's permissions (Pike roles) to allow creating, updating, and
-   deleting Grid products.
-
-   ```
-   root@gridd-alpha:/# grid \
-   agent update 314156 $(cat ~/.grid/keys/alpha-agent.pub) --active \
-   --role can_create_product \
-   --role can_update_product \
-   --role can_delete_product \
-   --role admin
-   ```
-
-6. Use `cat` to create a product definition file, `product.yaml`, using the
+1. Use `cat` to create a product definition file, `product.yaml`, using the
    following contents.
 
    ```
@@ -165,7 +128,7 @@ steps 3 through 10.
          number_value: 0
    ```
 
-7. Add a new product based on the definition in the example YAML file,
+1. Add a new product based on the definition in the example YAML file,
    `product.yaml`.
 
    ```
@@ -173,17 +136,17 @@ steps 3 through 10.
      product create  product.yaml
    ```
 
-8. Open a new terminal and connect to the `gridd-beta` container.
+1. Open a new terminal and connect to the `gridd-beta` container.
 
    `$ docker exec -it gridd-beta bash`
 
-9. Set an environment variable with the service ID.
+1. Set an environment variable with the service ID.
 
     ```
     root@gridd-beta:/# export GRID_SERVICE_ID=01234-ABCDE::gsBB
     ```
 
-10. Display all products.
+1. Display all products.
 
    ```
    root@gridd-beta:/# grid product list

--- a/docs/0.1/using_grid_features.md
+++ b/docs/0.1/using_grid_features.md
@@ -17,8 +17,9 @@ Likewise, each product schema must have an owning organization and an agent
 
 Follow these general steps when creating a new item:
 
-1. Create an organization with at least one agent that has the permissions to
-   create and manage the item.
+1. [Create an organization]({% link docs/0.1/creating_organizations.md %})
+   with at least one agent that has the permissions to create and manage the
+   item.
 
 1. Create a schema that defines the structure of the item's properties.
 


### PR DESCRIPTION
This new how-to procedure expands the original organization-creation steps (from "Running Grid on Splinter") with prerequisites, clarifying info, corrections, and subheadings for navigation. It also includes a section on setting Grid environment variables.
                                                                                
This PR also removes the organization and agent steps from Running Grid on Splinter. and replaces them with a link to the "Creating Organizations" procedure.        
                                                                                
Note: The product-creation steps will be removed in a separate PR. This commit renumbers the product-creation steps and reworks the environment variable info (changed to a note) for those steps.
 