### PR TITLE
Change jira references to github projects

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,10 +13,6 @@ description of the flaw and any related information (e.g. reproduction
 steps, version) to
 [security at hyperledger dot org](mailto:security@hyperledger.org).
 
-The other way is to file a confidential security bug in our
-[JIRA bug tracking system](https://jira.hyperledger.org).
-Be sure to set the “Security Level” to “Security issue”.
-
 The process by which the Hyperledger Security Team handles security bugs
 is documented further in our
 [Defect Response](https://wiki.hyperledger.org/display/HYP/Defect+Response)

--- a/community/contributing.md
+++ b/community/contributing.md
@@ -29,16 +29,16 @@ Ways you can contribute:
 * Tests for events and results: Add functional, performance, or scalability
   tests
 
-Hyperledger Grid issues are tracked in JIRA (see
-[Using JIRA]({% link community/issue_tracking.md %})).
+Hyperledger Grid issues are tracked in Github Projects (see
+[Using Github Projects]({% link community/issue_tracking.md %})).
 Any unassigned items are probably still open. When in doubt, ask on
 the [#grid](https://chat.hyperledger.org/channel/grid) chat channel about
-a specific JIRA issue (see
+a specific issue (see
 [Joining the Discussion]({% link community/join_the_discussion.md %})).
 
 ## The Commit Process
 
-Hyperledger Grid is Apache 2.0 licensed and accepts contributions via 
+Hyperledger Grid is Apache 2.0 licensed and accepts contributions via
 [GitHub](https://github.com/hyperledger/grid) pull requests. When contributing
 code, please follow these guidelines:
 
@@ -99,15 +99,3 @@ A pull request cannot merged until it has passed these status checks:
 
 * The PR must be approved by at least two reviewers without any outstanding
   requests for changes
-
-## Integrating GitHub Commits with JIRA
-
-You can link JIRA issues to your commits, which will integrate developer
-activity with the associated issue. JIRA uses the issue key to associate the
-commit with the issue, so that the commit can be summarized in the development
-panel for the JIRA issue.
-
-When you make a commit, add the JIRA issue key to the end of the commit message
-or to the branch name. Either method should integrate your commit with the JIRA
-issue that it references.
-

--- a/community/index.md
+++ b/community/index.md
@@ -22,7 +22,7 @@ specific tools and examples.
   feature proposals and work in progress.
 
 * [Track issues]({% link community/issue_tracking.md %}):
-  We use JIRA to track issues and report defects.
+  We use Github Projects to track issues and report defects.
 
 * [Contribute]({% link community/contributing.md %}):
   We welcome contributions to Hyperledger Grid, including bug reports, features

--- a/community/issue_tracking.md
+++ b/community/issue_tracking.md
@@ -11,24 +11,20 @@ A great way to contribute is by reporting issues. Before reporting an issue,
 please review the current open issues to see if someone has already reported
 the issue.
 
-## Using JIRA
+## Using Github Projects
 
-Hyperledger Grid uses JIRA as our issue tracking system:
+Hyperledger Grid uses Github Projects as our issue tracking system:
 
-<https://jira.hyperledger.org/projects/GRID>
+<https://github.com/orgs/hyperledger/projects/1>
 
 ## How to Report an Issue
 
-To report issues, log into [jira.hyperledger.org](https://jira.hyperledger.org),
-which requires a
-[Linux Foundation Account](https://identity.linuxfoundation.org/).
+Create issues in Github under the Hyperledger Grid project. If the issue is a
+bug, please apply the 'bug' label to the issue.
 
-Create issues in JIRA under the Hyperledger Grid project, which uses the
-`GRID` JIRA key.
-
-When reporting an issue, please provide as much detail as possible about how to
-reproduce it. If possible, explain how to reproduce the issue.  Details are
-very helpful. Please include the following information:
+When reporting an bug, please provide as much detail as possible about how to
+reproduce it. If possible, explain how to reproduce the bug.  Details are very
+helpful. Please include the following information:
 
 * OS version
 * Grid version
@@ -39,4 +35,4 @@ very helpful. Please include the following information:
 
 If you would like, you could also describe the issue on RocketChat (see
 [Joining the Discussion]({% link community/join_the_discussion.md %}))
-for initial feedback before submitting the issue in JIRA.
+for initial feedback before submitting the issue in Github.


### PR DESCRIPTION
Updates the info in the contributing sections to reference Github Projects instead of Jira