### PR TITLE
Add compose file for running grid-docs website

### DIFF
--- a/docker/compose/grid-website.yaml
+++ b/docker/compose/grid-website.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE: This compose file is to be used when deploying the live website, not
+# for test or development use. Place .scar files in /opt/grid-website/scar
+# and they will be available on the website in the /scar directory.
+
+version: '3.7'
+
+services:
+  grid-website:
+    image: hyperledger/grid-website
+    restart: always
+    volumes:
+      - /opt/grid-website/scar:/usr/local/apache2/htdocs/scar
+    ports:
+      - 8066:80


### PR DESCRIPTION
This compose file is to be used when deploying the live website, not
for test or development use. Place .scar files in `/opt/grid-website/scar`
and they will be available on the website in the /scar directory.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>