### PR TITLE
Switch Dockerfiles to use node:lts-stretch

### DIFF
--- a/ci/website.dockerfile
+++ b/ci/website.dockerfile
@@ -7,7 +7,7 @@
 
 # -------------=== redoc build ===-------------
 
-FROM node:lts-alpine as redoc
+FROM node:lts-stretch as redoc
 
 RUN npm install -g redoc
 RUN npm install -g redoc-cli

--- a/docker/grid-docs-redoc
+++ b/docker/grid-docs-redoc
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:lts-alpine
+FROM node:lts-stretch
 
 RUN npm install -g redoc
 RUN npm install -g redoc-cli


### PR DESCRIPTION
The "latest" image is based off stretch so lts-stretch is a better
replacement. This commit and commit 5753990c should be reverted
once https://github.com/Redocly/redoc/issues/1442 is resolved.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>