### PR TITLE
Link to other how-to guides for grid-on-splinter

### DIFF
--- a/docs/0.1/grid_on_splinter.md
+++ b/docs/0.1/grid_on_splinter.md
@@ -88,7 +88,6 @@ product properties, and creating a product.
 * [Creating Products]({% link docs/0.1/creating_products.md %}) shows how to
   create, update, and delete products as the organization's agent.
 
-
 ### Demonstrate Smart Contract Deployment
 
 You can use the `scabbard` CLI to deploy custom smart contracts on existing


### PR DESCRIPTION
Instead of having a separate process for running a grid on splinter
example, the doc now just links to the how-to guides for each smart
contract. This way we don't have to maintain the info in multiple
locations.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>