### PR TITLE
Add postgres DB docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 #jekyll stuff
 .jekyll-cache/
 _site/
+/database/
+
+**/.DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,7 @@ include:
 exclude:
   - CODEOWNERS
   - ci
+  - database
   - docker*
   - Jenkinsfile
   - justfile

--- a/_includes/0.1/left_sidebar.html
+++ b/_includes/0.1/left_sidebar.html
@@ -54,6 +54,7 @@
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Reference Guides</div>
         <a href="{% link docs/0.1/cli_references.md %}">CLI Command Reference</a>
+        <a href="{% link docs/0.1/references/database/index.md %}">Grid Database Reference</a>
         <a href="{% link docs/0.1/references/api/index.md %}">Grid REST API</a>
         <a href="{% link docs/0.1/references/rust_sdk/index.md %}">Grid Rust SDK Reference</a>
     </div>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,3 +49,33 @@ services:
       - 8080:80
     volumes:
       - .:/project
+      - ./database/postgres:/usr/local/apache2/htdocs/database/postgres
+
+  grid-docs-schemaspy:
+    container_name: grid-docs-schemaspy
+    image: grid-docs-schemaspy
+    build:
+      context: .
+      dockerfile: docker/schemaspy/Dockerfile
+    environment:
+      HOST: db
+      PORT: 5432
+      DATABASE: grid
+      USER: grid
+      PASSWORD: grid_example
+    depends_on:
+      - db
+    volumes:
+      - ./database/postgres:/output
+
+  db:
+    image: postgres
+    container_name: db
+    hostname: db
+    restart: always
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: grid
+      POSTGRES_PASSWORD: grid_example
+      POSTGRES_DB: grid

--- a/docker/grid-docs-apache
+++ b/docker/grid-docs-apache
@@ -23,6 +23,8 @@ AddDefaultCharset utf-8\n\
 LoadModule proxy_module modules/mod_proxy.so\n\
 LoadModule proxy_http_module modules/mod_proxy_http.so\n\
 LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so\n\
+ProxyPassMatch /docs/0.1/database !\n\
+Alias /docs/0.1/database/postgres /usr/local/apache2/htdocs/database/postgres/0.1/\n\
 ProxyPass /docs/0.1/api/ http://grid-docs-redoc-0-1:4001/\n\
 ProxyPassReverse /docs/0.1/api/ http://grid-docs-redoc-0-1:4001/\n\
 ProxyPass / http://grid-docs-jekyll:4000/\n\

--- a/docker/schemaspy/Dockerfile
+++ b/docker/schemaspy/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+FROM hyperledger/gridd:nightly
+
+RUN apt-get update \
+    && apt-get install -y -q \
+        build-essential \
+        graphviz \
+        libpq-dev \
+        openjdk-8-jre \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /output && \
+    mkdir -p /org/schemaspy/drivers && \
+    mkdir /schemaspy
+
+COPY docker/schemaspy/generate .
+
+COPY docker/schemaspy/pgsql11.properties /schemaspy
+
+RUN chmod a+x generate
+
+COPY --from=schemaspy/schemaspy:snapshot /usr/local/lib/schemaspy/schemaspy-6.1.1-SNAPSHOT.jar /schemaspy/schemaSpy.jar
+
+COPY --from=schemaspy/schemaspy:snapshot /drivers_inc/ /org/schemaspy/drivers
+
+RUN chmod a+x schemaspy/schemaSpy.jar
+
+ENTRYPOINT ["./generate"]

--- a/docker/schemaspy/generate
+++ b/docker/schemaspy/generate
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+rm -rf /output/*
+
+until PGPASSWORD=$PASSWORD psql -h $HOST -d $DATABASE -U $USER -c '\q'; do
+  >&2 echo "Database is unavailable - sleeping"
+  sleep 1
+done
+
+grid -vv database migrate \
+    --database-url postgres://grid:grid_example@db/grid
+
+java -jar schemaspy/schemaSpy.jar \
+    -t pgsql11 -host $HOST -port $PORT \
+    -db $DATABASE -u $USER -p $PASSWORD -o /output/0.1 \
+    -dp /org/schemaspy/drivers/postgresql-42.1.1.jre7.jar

--- a/docker/schemaspy/pgsql11.properties
+++ b/docker/schemaspy/pgsql11.properties
@@ -1,0 +1,18 @@
+# Copyright 2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+extends=pgsql
+selectRoutinesSql=select r.routine_name, case p.prokind when 'f' then 'FUNCTION' when 'p' then 'PROCEDURE' when 'a' then 'AGGREGATE' when 'w' then 'WINDOW' else 'UNKNOWN' end as routine_type, case when p.proretset then 'SETOF ' else '' end || case when r.data_type = 'USER-DEFINED' then r.type_udt_name else r.data_type end as dtd_identifier, r.external_language as routine_body, r.routine_definition, r.sql_data_access, r.security_type, r.is_deterministic, d.description as routine_comment from information_schema.routines r left join pg_namespace ns on r.routine_schema = ns.nspname left join pg_proc p on ns.oid = p.pronamespace and r.routine_name = p.proname left join pg_description d on d.objoid = p.oid where r.routine_schema = :schema
+selectRoutineParametersSql=select r.routine_name as specific_name, coalesce(p.parameter_name, '$' || p.ordinal_position) as parameter_name, p.data_type as dtd_identifier, p.parameter_mode from information_schema.parameters p left join information_schema.routines r on r.specific_name = p.specific_name where p.specific_schema = :schema order by p.specific_name, p.ordinal_position

--- a/docs/0.1/references/database/index.md
+++ b/docs/0.1/references/database/index.md
@@ -1,0 +1,12 @@
+# Grid Database Reference
+
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+The Grid database can be backed by either PostgreSQL or SQLite. The full
+schema for these backends can be found at:
+
+* [PostgreSQL schema](/docs/0.1/database/postgres)


### PR DESCRIPTION
This adds the schemaSpy-generated website containing the postgres grid
db docs. To test: run `just run` from the root and navigate to the
"Database Reference" section in the left navbar.