### PR TITLE
Update database migrate commands

### DIFF
--- a/docker/schemaspy/generate
+++ b/docker/schemaspy/generate
@@ -8,7 +8,7 @@ until PGPASSWORD=$PASSWORD psql -h $HOST -d $DATABASE -U $USER -c '\q'; do
 done
 
 grid -vv database migrate \
-    --database-url postgres://grid:grid_example@db/grid
+    -C postgres://grid:grid_example@db/grid
 
 java -jar schemaspy/schemaSpy.jar \
     -t pgsql11 -host $HOST -port $PORT \

--- a/docs/0.1/references/cli/grid-database-migrate.1.md
+++ b/docs/0.1/references/cli/grid-database-migrate.1.md
@@ -16,5 +16,5 @@ FLAGS:
     -v               Log verbosely
 
 OPTIONS:
-        --database-url <database_url>    URL for database
+    -C, --connect <database_url>    URL for database
 ```


### PR DESCRIPTION
This updates the database migrate commands to use the new `-C` argument
to pass the connection string. This replaces the `--database-url` arg.

Signed-off-by: Davey Newhall <newhall@bitwise.io>