### PR TITLE
Update name of monthly meeting from contributor to community

### DIFF
--- a/community/join_the_discussion.md
+++ b/community/join_the_discussion.md
@@ -22,9 +22,9 @@ involved conversations.
 [The Hyperledger Grid mailing list](https://lists.hyperledger.org/g/grid)
 provides a forum for both simple questions and more complex discussions.
 
-## Grid Contributor Meetings
+## Grid Community Meetings
 
-This project hosts Grid contributor meetings on Zoom. For meeting announcements,
+This project hosts Grid community meetings on Zoom. For meeting announcements,
 see the [Hyperledger meeting
 calendar](https://wiki.hyperledger.org/display/HYP/Calendar+of+Public+Meetings)
 or the [Grid mailing

--- a/community/planning/roadmap.md
+++ b/community/planning/roadmap.md
@@ -52,8 +52,8 @@ process](https://github.com/hyperledger/grid-rfcs).
 Considering adding a new feature to Grid? Awesome! Feel free to chat about it
 on [RocketChat in
 #grid]({% link community/join_the_discussion.md %}#chat)  or at
-one of our [contributor
-meetings]({% link community/join_the_discussion.md %}#grid-contributor-meetings)!
+one of our [community
+meetings]({% link community/join_the_discussion.md %}#grid-community-meetings)!
 
 ### Columns
 


### PR DESCRIPTION
The current terminology for our monthly meetings is 'Grid Community
Meeting'

