### PR TITLE
Add Pike overview to 0.2 navigation

### DIFF
--- a/_includes/0.2/left_sidebar.html
+++ b/_includes/0.2/left_sidebar.html
@@ -26,6 +26,7 @@
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Features</div>
+        <a href="{% link docs/0.2/grid_pike.md %}">Pike</a>
         <a href="{% link docs/0.2/grid_product.md %}">Product</a>
         <a href="{% link docs/0.2/grid_location.md %}">Location</a>
     </div>


### PR DESCRIPTION
This adds a link for the Pike overview to the left nav for the 0.2
version of the docs.

Signed-off-by: Davey Newhall <newhall@bitwise.io>