### PR TITLE
Rework product documentation for GDSN

### DIFF
--- a/docs/0.2/grid_product.md
+++ b/docs/0.2/grid_product.md
@@ -1,7 +1,7 @@
 # Grid Product
 
 <!--
-  Copyright 2018-2020 Cargill Incorporated
+  Copyright 2018-2021 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
   https://creativecommons.org/licenses/by/4.0/
 -->
@@ -13,16 +13,9 @@ features a flexible design that can be extended to other standards.
 
 With Grid Product, it's easy to define and share product-related data.
 
-* Uniquely identify each trade item with standard identifiers such as [GTINs
-  (Global Trade Item Numbers)](https://www.gs1.org/standards/id-keys/gtin).
-
-* Specify product properties using standards such as the [GS1 Attribute
-  Definitions for Business
-  (ADB)](https://www.gs1.org/standards/attribute-definitions-for-business ).
-
 Hyperledger Grid's modular architecture allows Grid Product to cleanly separate
 the product-related business rules from the creation and management of product
-data.  The Grid Product smart contract defines the product operations (create,
+data. The Grid Product smart contract defines the product operations (create,
 update, and delete). Other Grid utilities let users and applications define,
 manage, and query trade item data with command-line tools, YAML files, and
 web-based requests to REST API endpoints. As a result, product management is
@@ -30,10 +23,27 @@ easily handled without additional application development or smart contract
 creation.
 
 Grid Product can interact seamlessly with other smart contracts to manage owner
-and agent permissions,  product property templates (also called schemas),
+and agent permissions, product property templates (also called schemas),
 location data, and more.
 
 ![Grid Product architecture](images/grid_product.png)
 
 These components combine to submit transactions to the back-end distributed
 ledger, securely and efficiently sharing product data with all trading partners.
+
+By default, Grid Product supports the GDSN 3.1 trade item schema for product
+definitions. This allows users who already have product data conforming to this
+standard to easily submit their product definitions into Grid.
+
+To support this functionality, the Grid Product CLI provides functionality to
+parse and validate XML data against the [GridTradeItems XML Schema Definition](https://github.com/hyperledger/grid/blob/main/sdk/src/products/gdsn/GridTradeItems.xsd).
+The gridTradeItems element defined within the GridTradeItems XSD acts as a
+wrapper for tradeItems elements as defined in the GDSN
+[TradeItem XSD](http://www.gdsregistry.org/3.1/schemas/gs1/gdsn/TradeItem.xsd).
+Note that with this pattern, GDSN data is validated in the client, rather than
+in the smart contract.
+
+GDSN trade item standards were chosen as the default for Grid due to wide
+adoption of this format and the availability robust XML schemas available.
+However, if GDSN standards are not desirable for a use case, users can easily
+define schemas to support other standards as well.


### PR DESCRIPTION
Adds references to the GDSN specific functionality to the Product feature documentation. Also removes references to the application identifier pattern which is no longer the default.
