### PR TITLE
Add owner to location schema example

### DIFF
--- a/docs/0.2/creating_locations.md
+++ b/docs/0.2/creating_locations.md
@@ -64,6 +64,7 @@ needed.
   ```yaml
     - name: gs1_location
       description: GS1 location schema
+      owner: myorg
       properties:
         - name: locationDescription
           data_type: String


### PR DESCRIPTION
This adds the owner field to the location schema example. This field is
now required to be present in either the yaml or passed via the CLI.

Signed-off-by: Davey Newhall <newhall@bitwise.io>