### PR TITLE
Update "Creating Schemas" procedure

### DIFF
--- a/docs/0.2/creating_schemas.md
+++ b/docs/0.2/creating_schemas.md
@@ -232,7 +232,8 @@ identified in the schema definition.
 
    You don't have to use the same file that was used to create the schema,
    but the file must specify the same name and present the properties in the
-   same order.
+   same order. Only new properties may be added. Existing properties may not be
+   removed or modified in order to preserve the validity of existing data.
 
 1. Use the `update` subcommand for `grid schema` to submit the YAML file's
    changes to the distributed ledger.


### PR DESCRIPTION
This updates the "Update schema" section of the "Creating Schemas"
procedure to clarify that an updated schema definition cannot remove or
modify existing properties in order to preserve the validity of existing
data.

Signed-off-by: Davey Newhall <newhall@bitwise.io>