### PR TITLE
Add guide for upgrading smart contracts

### DIFF
--- a/_includes/0.2/left_sidebar.html
+++ b/_includes/0.2/left_sidebar.html
@@ -40,10 +40,12 @@
         <a href="{% link docs/0.2/creating_schemas.md %}">Creating Schemas</a>
         <a href="{% link docs/0.2/creating_products.md %}">Creating Products</a>
         <a href="{% link docs/0.2/creating_locations.md %}">Creating Locations</a>
+        <a href="{% link docs/0.2/upgrading_smart_contracts_for_administrators.md %}">Upgrading Smart Contracts For Administrators</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">For Developers</div>
         <a href="{% link docs/0.2/building_grid.md %}">Building Grid</a>
+        <a href="{% link docs/0.2/upgrading_smart_contracts_for_developers.md %}">Upgrading Smart Contracts For Developers</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Smart Contracts</div>

--- a/docs/0.2/upgrading_smart_contracts_for_administrators.md
+++ b/docs/0.2/upgrading_smart_contracts_for_administrators.md
@@ -1,0 +1,110 @@
+# Upgrading Smart Contracts
+
+<!--
+  Copyright (c) 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+This tutorial covers how to upgrade a smart contract. This procedure will focus
+on updating a smart contract for Grid on Splinter run using the Docker compose
+file located in `grid/examples/splinter`.
+
+## Prerequisites
+
+* Grid running on Splinter using the example Docker compose file
+
+* Access to the scabbard command line tool
+
+* An updated smart contract. Instructions for incrementing the protocol version
+  for a contract can be found in the [Upgrading Smart Contracts for Developers](/docs/0.2/upgrading_smart_contracts_for_developers.md)
+  section.
+
+## Procedure
+
+### Rebuild the Smart Contract
+
+This procedure will likely be done by an administrator for the Splinter circuit
+or network. These steps include rebuilding or compiling the upgraded contract
+and then deploying it.
+
+1. Rebuild the contract builder container (in this case, for the Pike smart
+   contract) and the Grid daemon containers.
+
+   ```
+   $ docker-compose -f examples/splinter/docker-compose.yaml build \
+        --no-cache pike-contract-builder gridd-alpha gridd-beta gridd-gamma
+   ```
+
+1. Restart those containers:
+
+   ```
+   $ docker-compose -f examples/splinter/docker-compose.yaml up \
+        --detach pike-contract-builder gridd-alpha gridd-beta gridd-gamma
+   ```
+
+## Important Note
+
+If not running using the example Docker compose files you will need to package
+the smart contract. A procedure for this can be found in the
+[Uploading smart contracts](/docs/0.2/uploading_smart_contracts.md) section.
+This will then need to be uploaded via Scabbard.
+
+### Add the contract to your circuit
+
+{:start="3"}
+
+3. Start a bash session in your node’s `scabbard-cli`
+Docker container (such as `scabbard-cli-alpha`).  You will use this container
+to run the `scabbard` commands to upload and configure the smart contract.
+
+   ```
+   $ docker exec -it scabbard-cli-alpha bash
+   root@scabbard-cli-alpha:/#
+   ```
+
+1. To simplify entering the `scabbard` commands in this procedure, set
+   `SERVICE_ID` to the fully qualified service ID for the scabbard service on
+   this circuit (such as `01234-ABCDE::gsAA`).
+
+   ```
+   root@scabbard-cli-alpha:/# export SERVICE_ID=01234-ABCDE::gsAA
+   ```
+
+1. Upload the updated contract:
+
+   ```
+   $ scabbard contract upload grid-pike:0.2.2 \
+        --path ./usr/share/scar \
+        -k gridd \
+        -U 'http://splinterd-alpha:8085' \
+        --service-id $SERVICE_ID
+   ```
+
+   You can verify that the contract was added successfully using the command:
+
+   ```
+   $ scabbard contract list \
+        -U 'http://splinterd-alpha:8085' \
+        --service-id $SERVICE_ID
+   ```
+
+1. If the address prefix for the contract changes in your update, create a new
+   namespace:
+
+   ```
+   $ scabbard ns create <prefix> \
+        --owner <alpha_node_public_key> \
+        --key <path_to_alpha_node_private_key> \
+        --url http://splinterd-alpha:8080 \
+        --service-id $CIRCUIT_ID::scabbard-service-alpha
+    ```
+
+1. Update the permissions for the namespace:
+
+    ```
+    $ scabbard perm <prefix> my_contract --read --write \
+        --key <path_to_alpha_node_private_key> \
+        --url http://splinterd-alpha:8080 \
+        --service-id $CIRCUIT_ID::scabbard-service-alpha
+    ```

--- a/docs/0.2/upgrading_smart_contracts_for_developers.md
+++ b/docs/0.2/upgrading_smart_contracts_for_developers.md
@@ -1,0 +1,37 @@
+# Upgrading Smart Contracts
+
+<!--
+  Copyright (c) 2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+This tutorial covers how to upgrade a smart contract. This procedure will focus
+on updating a smart contract for Grid on Splinter run using the Docker compose
+file located in `grid/examples/splinter`.
+
+There are two sets of tasks associated with upgrading a smart contract. The
+first set will likely be done by a developer working on the smart contract
+itself and will be covered in this section. The second set will likely be done
+by an administrator to actually deploy the smart contract. This document can be
+found in the [Upgrading Smart Contracts for Administrators](/docs/0.2/upgrading_smart_contracts_for_administrators.md)
+section.
+
+## Procedure
+
+### Update the Smart Contract
+
+This set of steps will likely be done by a developer working on the smart
+contract code. These steps increment the protocol version of the smart contract
+alongside functional changes and get the smart contract ready for deployment.
+
+1. Update the `manifest.yaml` and `<contract_name>.yaml` files for the smart
+   contract with updated inputs, outputs, and increment the protocol version
+   number.
+
+1. Increment the family version constants for the Smart Contract in the
+   following files:
+
+     * `grid/cli/src/transaction.rs`
+
+     * `grid/contracts/<contract_name>/src/handler.rs`


### PR DESCRIPTION
This adds guides for upgrading a smart contract to a new version. This
splits the procedure into two docs, one for developers and one for
administrators