### PR TITLE
Update release pages to link to release branch

### DIFF
--- a/releases/0.1/download.md
+++ b/releases/0.1/download.md
@@ -8,10 +8,13 @@
 
 ## Grid repository
 
-Clone the core [GitHub repository](https://github.com/hyperledger/grid)
+Clone the core [GitHub repository](https://github.com/hyperledger/grid/tree/0-1)
 to view the Grid source code, demo applications, and example Docker compose
 files for starting up a Grid network. Learn more
 by browsing the [Grid documentation]({% link docs/0.1/index.md %}).
+
+NOTE: Grid v0.1 exists as a branch on the core repository. Checkout the `0-1`
+branch after cloning the core to view the Grid v0.1 source code.
 
 ## Grid-contrib repository
 

--- a/releases/0.2/download.md
+++ b/releases/0.2/download.md
@@ -8,10 +8,13 @@
 
 ## Grid repository
 
-Clone the core [GitHub repository](https://github.com/hyperledger/grid)
+Clone the core [GitHub repository](https://github.com/hyperledger/grid/tree/0-2)
 to view the Grid source code, demo applications, and example Docker compose
 files for starting up a Grid network. Learn more
 by browsing the [Grid documentation]({% link docs/0.2/index.md %}).
+
+NOTE: Grid v0.2 exists as a branch on the core repository. Checkout the `0-2`
+branch after cloning the core to view the Grid v0.2 source code.
 
 ## Grid-contrib repository
 


### PR DESCRIPTION
This change updates the links used in the `Releases` pages for Grid v0.1
and v0.2 to update the GitHub link to point to the specific release
branch. This change also adds a note to these release pages to specify
that the released version exists on a branch, rather than just the core
repository.

Signed-off-by: Shannyn Telander <telander@bitwise.io>