### PR TITLE
Change `POSTGRES_HOST_AUTH_METHOD` to `trust`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -96,7 +96,6 @@ services:
       PORT: 5432
       DATABASE: grid
       USER: grid
-      PASSWORD: grid_example
     depends_on:
       - db
     volumes:
@@ -124,7 +123,6 @@ services:
       PORT: 5432
       DATABASE: grid
       USER: grid
-      PASSWORD: grid_example
     depends_on:
       - db
     volumes:
@@ -152,7 +150,6 @@ services:
       PORT: 5432
       DATABASE: grid
       USER: grid
-      PASSWORD: grid_example
     depends_on:
       - db
     volumes:
@@ -178,5 +175,5 @@ services:
       - 5432
     environment:
       POSTGRES_USER: grid
-      POSTGRES_PASSWORD: grid_example
       POSTGRES_DB: grid
+      POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
This fixes an authentication error in Schemaspy after the Postgres 14
release.

trust authorization is not recommended for deployed databases, but is
acceptable in this instance because the database is only being used to generate
schema for documentation purposes.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>