### PR TITLE
Update roadmap to reflect plans for Grid v0.3

### DIFF
--- a/community/planning/roadmap.md
+++ b/community/planning/roadmap.md
@@ -49,8 +49,8 @@ in some form.
 
 | Feature | Status | RFC | Issues | Documentation |
 | ------- | ------ | --- | ------- | ------------- |
-| Identity (Pike 2) | *Implemented* | [RFC #23](https://github.com/hyperledger/grid-rfcs/pull/23) | ["identity"](https://github.com/orgs/hyperledger/projects/1?card_filter_query=label%3A%22epic%3A+grid+identity%22) | - |
-| Product w/GDSN Trade Items| *Implemented* | - | - |
+| Identity (Pike 2) | *Complete* | [RFC #23](https://github.com/hyperledger/grid-rfcs/pull/23) | ["identity"](https://github.com/orgs/hyperledger/projects/1?card_filter_query=label%3A%22epic%3A+grid+identity%22) | - |
+| Product w/GDSN Trade Items| *Complete* | - | - |
 | Update to Actix 3 | *Complete* | - | - | - |
 
 ## Additional Information


### PR DESCRIPTION
This also makes some other modifications to the page, such as removing primary contact and moving Grid v0.2 to past releases.