### PR TITLE
Fix location of API doc

### DIFF
--- a/ci/website.dockerfile
+++ b/ci/website.dockerfile
@@ -62,7 +62,7 @@ FROM httpd:2.4
 COPY --from=redoc /index_0.1.html /usr/local/apache2/htdocs/docs/0.1/api/index.html
 COPY --from=redoc /index_0.2.html /usr/local/apache2/htdocs/docs/0.2/api/index.html
 COPY --from=redoc /index_0.3.html /usr/local/apache2/htdocs/docs/0.3/api/index.html
-COPY --from=redoc /rest_api_planning.html /usr/local/apache2/htdocs/community/planning/rest_api/index.html
+COPY --from=redoc /rest_api_planning.html /usr/local/apache2/htdocs/community/planning/rest_api/api/index.html
 COPY --from=jekyll /tmp/ /usr/local/apache2/htdocs/
 COPY ./database/postgres/0.1 /usr/local/apache2/htdocs/docs/0.1/database/postgres
 COPY ./database/sqlite/0.1 /usr/local/apache2/htdocs/docs/0.1/database/sqlite


### PR DESCRIPTION
This fixes the location of the API doc when the website is getting
built. Previously, the file was being overwritten.

Signed-off-by: Davey Newhall <newhall@bitwise.io>