### PR TITLE
Update Grid docs for 0.3 release

### DIFF
--- a/docs/0.3/glossary.md
+++ b/docs/0.3/glossary.md
@@ -68,6 +68,13 @@ Grid Product
 Smart contract for defining and sharing product data (trade item data).
 </p>
 
+<h3 class="glossary-header" id="grid_purchase_order">
+Grid Purchase Order
+</h3>
+<p class="glossary-definition">
+Smart contract for creating and managing purchase orders between organizations.
+</p>
+
 <h3 class="glossary-header" id="grid_track_and_trace">
 Grid Track and Trace
 </h3>

--- a/docs/0.3/grid_on_sawtooth.md
+++ b/docs/0.3/grid_on_sawtooth.md
@@ -7,7 +7,7 @@ Grid-on-Sawtooth environment that runs in a set of Docker containers.
 The example Sawtooth [docker-compose](https://github.com/hyperledger/grid/blob/master/examples/sawtooth/docker-compose.yaml)
 file creates a network with two nodes (alpha and beta) that can be used for
 demos or application development. This environment includes the Pike, Product,
-Location, and Schema smart contracts.
+Location, Purchase Order, and Schema smart contracts.
 
 - **Pike** handles organization and identity permissions with the Sabre smart
   contract engine.
@@ -37,7 +37,8 @@ Location, and Schema smart contracts.
    `$ docker-compose -f examples/sawtooth/docker-compose.yaml up`
 
    This docker-compose file creates a network with two nodes (alpha and beta)
-   that includes the Pike, Schema, and Product smart contracts.
+   that includes the Pike, Schema, Location, Purchase Order, and Product smart
+   contracts.
 
 ## Next Steps
 
@@ -62,6 +63,10 @@ product properties, and creating a product.
 
 * [Creating Products]({% link docs/0.3/creating_products.md %}) shows how to
   create, update, and delete products as the organization's agent.
+
+* [Using Purchase Order]({% link docs/0.3/using_purchase_order.md %}) shows how
+  to create and update purchase orders and versions and manage them between
+  organizations.
 
 ### Smart Contract Deployment
 

--- a/docs/0.3/grid_on_splinter.md
+++ b/docs/0.3/grid_on_splinter.md
@@ -6,7 +6,8 @@ environment that runs in a set of Docker containers.
 
 The example Splinter docker-compose file creates a network with three nodes
 (alpha, beta, and gamma) that can be used for demos or application development.
-This environment includes the Pike, Product, and Schema smart contracts.
+This environment includes the Pike, Product, Location, Purchase Order, and
+Schema smart contracts.
 
 - **Pike** handles organization and identity permissions with Sabre, a smart
   contract engine that is included in the Splinter scabbard service.
@@ -48,7 +49,8 @@ $ docker-compose -f examples/splinter/docker-compose.yaml pull generate-registry
    `$ docker-compose -f examples/splinter/docker-compose.yaml up`
 
    This docker-compose file creates a network with two nodes (alpha and beta)
-   that includes the Pike, Schema, and Product smart contracts.
+   that includes the Pike, Schema, Location, Purchase Order, and Product smart
+   contracts.
 
 ## Next Steps
 
@@ -87,6 +89,10 @@ product properties, and creating a product.
 
 * [Creating Products]({% link docs/0.3/creating_products.md %}) shows how to
   create, update, and delete products as the organization's agent.
+
+* [Using Purchase Order]({% link docs/0.3/using_purchase_order.md %}) shows how
+  to create and update purchase orders and versions and manage them between
+  organizations.
 
 
 ### Demonstrate Smart Contract Deployment

--- a/docs/0.3/references/addressing_reference.md
+++ b/docs/0.3/references/addressing_reference.md
@@ -57,6 +57,14 @@ section in the smart contract specification for any Grid smart contract.
       Alternate ID Index: <code>03</code>
     </td>
   </tr>
+    <tr>
+    <td>Purchase Order</td>
+    <td><code>621dee06</code></td>
+    <td>
+      Purchase Orders: <code>00</code><br>
+      Alternate ID: <code>01</code>
+    </td>
+  </tr>
   <tr>
     <td>Track and Trace</td>
     <td><code>a43b46</code></td>

--- a/docs/0.3/upgrading_smart_contracts_for_administrators.md
+++ b/docs/0.3/upgrading_smart_contracts_for_administrators.md
@@ -28,19 +28,19 @@ This procedure will likely be done by an administrator for the Splinter circuit
 or network. These steps include rebuilding or compiling the upgraded contract
 and then deploying it.
 
-1. Rebuild the contract builder container (in this case, for the Pike smart
-   contract) and the Grid daemon containers.
+1. Rebuild the contract builder container (in this case, for the Purchase Order
+   smart contract) and the Grid daemon containers.
 
    ```
    $ docker-compose -f examples/splinter/docker-compose.yaml build \
-        --no-cache pike-contract-builder gridd-alpha gridd-beta gridd-gamma
+        --no-cache purchase-order-contract-builder gridd-alpha gridd-beta gridd-gamma
    ```
 
 1. Restart those containers:
 
    ```
    $ docker-compose -f examples/splinter/docker-compose.yaml up \
-        --detach pike-contract-builder gridd-alpha gridd-beta gridd-gamma
+        --detach purchase-order-contract-builder gridd-alpha gridd-beta gridd-gamma
    ```
 
 ## Important Note
@@ -74,7 +74,7 @@ to run the `scabbard` commands to upload and configure the smart contract.
 1. Upload the updated contract:
 
    ```
-   $ scabbard contract upload grid-pike:0.3.2 \
+   $ scabbard contract upload grid-purchase-order:0.3.1 \
         --path ./usr/share/scar \
         -k gridd \
         -U 'http://splinterd-alpha:8085' \

--- a/releases/0.2/index.md
+++ b/releases/0.2/index.md
@@ -1,12 +1,10 @@
 # Grid v0.2 Release
 
 <!--
-  Copyright 2018-2021 Cargill Incorporated
+  Copyright 2018-2022 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
   https://creativecommons.org/licenses/by/4.0/
 -->
-
-Note: This release is currently in development.
 
 If you're new to Grid, see the [Grid documentation]({% link docs/0.2/index.md %})
 to learn about Grid concepts and features.

--- a/releases/0.3/index.md
+++ b/releases/0.3/index.md
@@ -1,0 +1,34 @@
+# Grid v0.3 Release
+
+<!--
+  Copyright 2018-2022 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+If you're new to Grid, see the [Grid documentation]({% link docs/0.3/index.md %})
+to learn about Grid concepts and features.
+
+Grid v0.3 is the third major release of Grid. Below is a summary of the
+features and changes included in this release. For detailed changes related to
+the v0.3 release, see the [Grid release notes](https://github.com/hyperledger/grid/blob/0-3/RELEASE_NOTES.md).
+
+## New and Noteworthy
+
+### Grid Puchase Order
+
+Grid Purchase Order is designed to share purchasing information between trade
+partners. The purchase of goods and services is a primary activity within the
+supply chain and the communication of order information occurs in various ways
+today: by phone, email, SMS, eCommerce marketplaces, Electronic Data
+Interchange (EDI), etc. Both the manual coordination and automated,
+point-to-point sharing of purchasing information between trade partners present
+challenges within day-to-day supply chain operations. Pain points include: poor
+data accuracy stemming from manual data entry errors, discrepancies between
+systems which impact receiving or result in financial claims, costs related to
+administrative/clerical time, and management of custom integrations.
+
+Grid Purchase Order aims to address these pain points by offering a common
+industry solution for sharing purchase order information between trade partners
+on Grid. Trade partners have the option to integrate this Grid component with
+existing systems of record.

--- a/releases/0.3/upgrading/README.md
+++ b/releases/0.3/upgrading/README.md
@@ -1,0 +1,13 @@
+# Upgrading to the lastest Grid v0.3 release
+
+<!--
+  Copyright 2018-2022 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+The following guides explain how to upgrade from one Grid release to the next
+release.
+
+  * [Upgrading to Grid v0.3.1 from Grid
+    v0.2.3]({% link releases/0.3/upgrading/grid-v0.3.1-from-v0.2.3.md %})

--- a/releases/0.3/upgrading/grid-v0.3.1-from-v0.2.3.md
+++ b/releases/0.3/upgrading/grid-v0.3.1-from-v0.2.3.md
@@ -1,0 +1,31 @@
+# Upgrading to Grid v0.3.1 from Grid v0.2.3
+
+<!--
+  Copyright 2018-2022 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+## Changes
+
+- [Smart Contract Updates](#smart-contract-updates)
+
+## Smart Contract Updates
+
+Grid has a new smart contract, Purchase Order. This contract allows for the
+creation and management of purchase orders between organizations. This contract
+is new and must be added to the contract registry for the Grid network. The
+[next section](#grid-purchase-order) has some recommendations for how to do
+this. For more information about these specific changes, please see the
+[Release Overview](/releases/0.3/index.md#grid-purchase-order).
+
+To add the new smart contract after upgrading to Grid 0.3, please follow the
+[Upgrading Smart Contracts for Administrators](/docs/0.3/upgrading_smart_contracts_for_administrators.md)
+guide.
+
+### Grid Purchase Order
+
+Prior to upgrading to Grid 0.3, the following steps are recommended:
+
+- If you wish to use the same keys for your agents after upgrading, save each
+  key along with the roles that they are permitted to.


### PR DESCRIPTION
This adds a brief upgrading procedure for upgrading Grid from version
0.2 to version 0.3. Other sections are also updated to include references to
the addition of Purchase Order functionality.

Signed-off-by: Davey Newhall newhall@bitwise.io