### PR TITLE
Fix permissions for using Grid Location

### DIFF
--- a/docs/0.2/creating_locations.md
+++ b/docs/0.2/creating_locations.md
@@ -232,8 +232,7 @@ information on creating and setting roles.
     myorg location-admin \
     --description "location admin permissions" \
     --active \
-    --permissions "location::can-create-location,location::can-update-location,\
-    location::can-delete-location"
+    --permissions "location::can-create-location,location::can-update-location,location::can-delete-location"
     ```
 
 1. Set the appropriate permissions for the agent. This example allows the

--- a/docs/0.3/creating_locations.md
+++ b/docs/0.3/creating_locations.md
@@ -232,8 +232,7 @@ information on creating and setting roles.
     myorg location-admin \
     --description "location admin permissions" \
     --active \
-    --permissions "location::can-create-location,location::can-update-location,\
-    location::can-delete-location"
+    --permissions "location::can-create-location,location::can-update-location,location::can-delete-location"
     ```
 
 1. Set the appropriate permissions for the agent. This example allows the

--- a/docs/0.4/creating_locations.md
+++ b/docs/0.4/creating_locations.md
@@ -232,8 +232,7 @@ information on creating and setting roles.
     myorg location-admin \
     --description "location admin permissions" \
     --active \
-    --permissions "location::can-create-location,location::can-update-location,\
-    location::can-delete-location"
+    --permissions "location::can-create-location,location::can-update-location,location::can-delete-location"
     ```
 
 1. Set the appropriate permissions for the agent. This example allows the


### PR DESCRIPTION
This change fixes the line in the `Creating Locations` guide used to
create the role with permissions to create, update, and delete a
location. Previously, the list of permissions was broken up by a `\` to
allow it to span multiple lines. However, this was creating a space in
the `location::can-delete-location` permission that disabled Grid from
being able to recognize this permission. This change removes the back
slash and keeps the permissions on one line, which still allows for
linting to pass and does not cause a space to occur in the permissions
string.

Signed-off-by: Shannyn Telander <telander@bitwise.io>