### PR TITLE
Update Upgrading Smart Contracts

### DIFF
--- a/docs/0.2/upgrading_smart_contracts_for_administrators.md
+++ b/docs/0.2/upgrading_smart_contracts_for_administrators.md
@@ -28,6 +28,9 @@ This procedure will likely be done by an administrator for the Splinter circuit
 or network. These steps include rebuilding or compiling the upgraded contract
 and then deploying it.
 
+> If you wish to use the same keys for your agents after upgrading, save each
+> key located in `/root/.grid/keys for each node before proceding.
+
 1. Rebuild the contract builder container (in this case, for the Pike smart
    contract) and the Grid daemon containers.
 

--- a/docs/0.3/upgrading_smart_contracts_for_administrators.md
+++ b/docs/0.3/upgrading_smart_contracts_for_administrators.md
@@ -28,6 +28,9 @@ This procedure will likely be done by an administrator for the Splinter circuit
 or network. These steps include rebuilding or compiling the upgraded contract
 and then deploying it.
 
+> If you wish to use the same keys for your agents after upgrading, save each
+> key located in `/root/.grid/keys for each node before proceding.
+
 1. Rebuild the contract builder container (in this case, for the Purchase Order
    smart contract) and the Grid daemon containers.
 

--- a/docs/0.4/upgrading_smart_contracts_for_administrators.md
+++ b/docs/0.4/upgrading_smart_contracts_for_administrators.md
@@ -28,8 +28,11 @@ This procedure will likely be done by an administrator for the Splinter circuit
 or network. These steps include rebuilding or compiling the upgraded contract
 and then deploying it.
 
-1. Rebuild the contract builder container (in this case, for the Pike smart
-   contract) and the Grid daemon containers.
+> If you wish to use the same keys for your agents after upgrading, save each
+> key located in `/root/.grid/keys for each node before proceding.
+
+1. Rebuild the contract builder container (in this case, for the Purchase Order
+   smart contract) and the Grid daemon containers.
 
    ```
    $ docker-compose -f examples/splinter/docker-compose.yaml build \


### PR DESCRIPTION
Adds a warning for users to save their keys before rebuilding the
daemons. Also fixes a typo.

Signed-off-by: Chris Eckhardt <eckhardt@bitwise.io>