### PR TITLE
Fix left sidebar for 0-4 docs

### DIFF
--- a/_includes/0.4/left_sidebar.html
+++ b/_includes/0.4/left_sidebar.html
@@ -11,12 +11,12 @@
     <div class="dropdown-menu">
         <div class="dropdown-header">Stable</div>
         <a class="dropdown-item" href="/docs/{{ site.data.general.latest_version }}/">
-            Latest ({{ site.data.general.latest_version }})
+            v{{ site.data.general.latest_version }} (Latest)
         </a>
+        <a class="dropdown-item" href="{% link docs/0.2/index.md %}">v0.2</a>
         <a class="dropdown-item" href="{% link docs/0.1/index.md %}">v0.1</a>
         <div class="dropdown-divider"></div>
         <div class="dropdown-header">Development</div>
-        <a class="dropdown-item" href="{% link docs/0.3/index.md %}">v0.3</a>
         <a class="dropdown-item" href="{% link docs/0.4/index.md %}">v0.4</a>
     </div>
 </div>


### PR DESCRIPTION
This change updates the left sidebar for the 0-4 section of the docs to
correctly show v0.3 as the "Latest" release and "Stable", rather than
"In Development".

Signed-off-by: Shannyn Telander <telander@bitwise.io>