### PR TITLE
Install Jekyll on ruby instead of using published image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     entrypoint:  |
       bash -c "
         rm -rf  _site
-        jekyll serve --config ./_config.yml
+        jekyll serve -H 0.0.0.0 --config ./_config.yml
       "
 
   grid-docs-redoc-0-1:

--- a/docker/jekyll.dockerfile
+++ b/docker/jekyll.dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM jekyll/jekyll:3.8
+FROM ruby
+
+RUN gem install jekyll -- --use-system-libaries
 
 RUN gem install \
     bundler \
@@ -23,3 +25,13 @@ RUN gem install \
     jekyll-seo-tag \
     jekyll-target-blank \
     jekyll-titles-from-headings
+
+RUN gem install webrick
+
+ENV JEKYLL_ENV=development
+
+CMD ["jekyll", "--help"]
+WORKDIR /srv/jekyll
+VOLUME  /srv/jekyll
+EXPOSE 35729
+EXPOSE 4000


### PR DESCRIPTION
The `ruby` base image is published for multiple architectures, so this
change ensures that the jekyll image runs without emulation.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>