### PR TITLE
Update batch submitter design doc

### DIFF
--- a/community/images/grid_batch_submitter.svg
+++ b/community/images/grid_batch_submitter.svg
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xl="http://www.w3.org/1999/xlink" viewBox="47 114 1260 662" width="1260" height="662">
+  <defs>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+  </defs>
+  <g id="Canvas_1" fill="none" stroke="none" fill-opacity="1" stroke-opacity="1" stroke-dasharray="none">
+    <title>Canvas 1</title>
+    <rect fill="white" x="47" y="114" width="1260" height="662"/>
+    <g id="Canvas_1_Layer_1">
+      <title>Layer 1</title>
+      <g id="Graphic_38">
+        <rect x="277" y="116" width="798.5" height="658" fill="#c0ffc0"/>
+        <rect x="277" y="116" width="798.5" height="658" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+        <text transform="translate(282 121)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="347.146" y="16">SUBMITTER</tspan>
+        </text>
+      </g>
+      <g id="Graphic_39">
+        <rect x="522" y="150.5" width="536" height="387" fill="#ffc0ff"/>
+        <rect x="522" y="150.5" width="536" height="387" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+        <text transform="translate(527 155.5)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="195.592" y="16">ASYNC RUNTIME</tspan>
+        </text>
+      </g>
+      <g id="Graphic_2">
+        <rect x="290.5" y="187.5" width="215.5" height="325.5" fill="#c0ffff"/>
+        <rect x="290.5" y="187.5" width="215.5" height="325.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(295.5 192.5)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="48.974" y="15">MAIN THREAD</tspan>
+        </text>
+      </g>
+      <g id="Graphic_3">
+        <rect x="536.5" y="187.5" width="215.5" height="230" fill="#c0c0ff"/>
+        <rect x="536.5" y="187.5" width="215.5" height="230" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(541.5 192.5)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="30.654" y="15">SPAWNER THREAD</tspan>
+        </text>
+      </g>
+      <g id="Graphic_4">
+        <rect x="826.25" y="187.5" width="215.5" height="325.5" fill="#ffffc0"/>
+        <rect x="826.25" y="187.5" width="215.5" height="325.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(831.25 192.5)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="43.782" y="15">TASK HANDLER</tspan>
+        </text>
+      </g>
+      <g id="Graphic_5">
+        <rect x="1090.5" y="187.5" width="215.5" height="574" fill="#ffc0c0"/>
+        <rect x="1090.5" y="187.5" width="215.5" height="574" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(1095.5 192.5)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="88.814" y="15">DLT</tspan>
+        </text>
+      </g>
+      <g id="Graphic_6">
+        <rect x="47.5" y="187.5" width="215.5" height="271" fill="#ffc0c0"/>
+        <rect x="47.5" y="187.5" width="215.5" height="271" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(52.5 192.5)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="69.862" y="15">QUEUER</tspan>
+        </text>
+      </g>
+      <g id="Graphic_7">
+        <rect x="47.5" y="490.5" width="215.5" height="271" fill="#ffc0c0"/>
+        <rect x="47.5" y="490.5" width="215.5" height="271" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(52.5 495.5)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="20.078" y="15">DATABASE VIA STORE</tspan>
+        </text>
+      </g>
+      <g id="Graphic_11">
+        <title>NewBatch</title>
+        <rect x="102.25" y="240" width="106" height="27" fill="white"/>
+        <rect x="102.25" y="240" width="106" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(107.25 244.5)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="9.59375" y="13">NewBatch</tspan>
+        </text>
+      </g>
+      <g id="Graphic_14">
+        <title>NewTask</title>
+        <rect x="325.5" y="240" width="145.5" height="99.5" fill="#ffffc0"/>
+        <rect x="325.5" y="240" width="145.5" height="99.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(330.5 245)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="34.14453" y="13">NewTask</tspan>
+        </text>
+      </g>
+      <g id="Graphic_13">
+        <title>NewBatch</title>
+        <rect x="345.25" y="276.25" width="106" height="27" fill="white"/>
+        <rect x="345.25" y="276.25" width="106" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(350.25 280.75)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="9.59375" y="13">NewBatch</tspan>
+        </text>
+      </g>
+      <g id="Graphic_12">
+        <title>Sender</title>
+        <rect x="345.25" y="306.5" width="106" height="27" fill="white"/>
+        <rect x="345.25" y="306.5" width="106" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(350.25 311)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="19.195312" y="13">Sender</tspan>
+        </text>
+      </g>
+      <g id="Graphic_17">
+        <title>NewTask</title>
+        <rect x="571.5" y="240" width="145.5" height="99.5" fill="#ffffc0"/>
+        <rect x="571.5" y="240" width="145.5" height="99.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(576.5 245)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="34.14453" y="13">NewTask</tspan>
+        </text>
+      </g>
+      <g id="Graphic_16">
+        <title>NewBatch</title>
+        <rect x="591.25" y="276.25" width="106" height="27" fill="white"/>
+        <rect x="591.25" y="276.25" width="106" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(596.25 280.75)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="9.59375" y="13">NewBatch</tspan>
+        </text>
+      </g>
+      <g id="Graphic_47">
+        <rect x="290.5" y="532.375" width="215.5" height="229.125" fill="#c0ffff"/>
+        <rect x="290.5" y="532.375" width="215.5" height="229.125" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(295.5 537.375)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="31.646" y="15">LISTENER THREAD</tspan>
+        </text>
+      </g>
+      <g id="Graphic_15">
+        <title>Sender</title>
+        <rect x="591.25" y="306.5" width="106" height="27" fill="white"/>
+        <rect x="591.25" y="306.5" width="106" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(596.25 311)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="19.195312" y="13">Sender</tspan>
+        </text>
+      </g>
+      <g id="Graphic_19">
+        <title>NewBatch</title>
+        <rect x="881" y="276.25" width="106" height="27" fill="white"/>
+        <rect x="881" y="276.25" width="106" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(886 280.75)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="9.59375" y="13">NewBatch</tspan>
+        </text>
+      </g>
+      <g id="Graphic_18">
+        <title>Sender</title>
+        <rect x="881" y="330.5" width="106" height="27" fill="white"/>
+        <rect x="881" y="330.5" width="106" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(886 335)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="19.195312" y="13">Sender</tspan>
+        </text>
+      </g>
+      <g id="Line_21">
+        <path d="M 155.25 267 L 155.25 289.75 L 335.35 289.75" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_22">
+        <line x1="471" y1="289.75" x2="561.6" y2="289.75" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_23">
+        <path d="M 717 289.75 L 771.625 289.75 L 771.625 350.25 L 816.35 350.25" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_24">
+        <rect x="1118.5" y="254" width="159.5" height="71.5" fill="white"/>
+        <rect x="1118.5" y="254" width="159.5" height="71.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(1123.5 280.526)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="20.222" y="15">POST /batches</tspan>
+        </text>
+      </g>
+      <g id="Graphic_26">
+        <title>NewBatch</title>
+        <rect x="1105.25" y="465" width="186" height="27" fill="white"/>
+        <rect x="1105.25" y="465" width="186" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(1110.25 469.5)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="1.5859375" y="13">SubmissionResponse</tspan>
+        </text>
+      </g>
+      <g id="Line_27">
+        <line x1="987" y1="289.75" x2="1108.6" y2="289.75" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_28">
+        <line x1="1198.25" y1="325.5" x2="1198.25" y2="455.1" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_29">
+        <title>NewBatch</title>
+        <rect x="841" y="465" width="186" height="27" fill="white"/>
+        <rect x="841" y="465" width="186" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(846 469.5)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="1.5859375" y="13">SubmissionResponse</tspan>
+        </text>
+      </g>
+      <g id="Line_30">
+        <line x1="1105.25" y1="478.5" x2="1036.9" y2="478.5" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_31">
+        <line x1="934" y1="357.5" x2="934" y2="455.1" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_32">
+        <title>NewBatch</title>
+        <rect x="305.25" y="637.5" width="186" height="27" fill="white"/>
+        <rect x="305.25" y="637.5" width="186" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(310.25 642)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="1.5859375" y="13">SubmissionResponse</tspan>
+        </text>
+      </g>
+      <g id="Line_33">
+        <path d="M 934 492 L 934 651 L 501.15 651" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_34">
+        <rect x="744.1765" y="636" width="92.20138" height="30" fill="white"/>
+        <text transform="translate(749.1765 641)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="27711167e-20" y="15">via </tspan>
+          <tspan font-family="Courier New" font-size="16" fill="black" y="15">Sender</tspan>
+        </text>
+      </g>
+      <g id="Graphic_35">
+        <title>NewBatch</title>
+        <rect x="303.25" y="700.25" width="190" height="27" fill="white"/>
+        <rect x="303.25" y="700.25" width="190" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(308.25 705.75)" fill="black">
+          <tspan font-family="Courier New" font-size="14" fill="black" x="1.7856445" y="12">update_batch_status()</tspan>
+        </text>
+      </g>
+      <g id="Line_36">
+        <line x1="398.25" y1="664.5" x2="398.25" y2="690.35" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_40">
+        <rect x="75.5" y="698.75" width="159.5" height="30" fill="white"/>
+        <rect x="75.5" y="698.75" width="159.5" height="30" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(80.5 704.526)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="29.846" y="15">state update</tspan>
+        </text>
+      </g>
+      <g id="Line_41">
+        <line x1="303.25" y1="713.75" x2="244.9" y2="713.75" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_44">
+        <title>Sender</title>
+        <rect x="324.25" y="422.4375" width="148" height="27" fill="white"/>
+        <rect x="324.25" y="422.4375" width="148" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(329.25 426.9375)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="1.7890625" y="13">channel_sender</tspan>
+        </text>
+      </g>
+      <g id="Line_45">
+        <line x1="398.25" y1="422.4375" x2="398.25" y2="343.4" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_46">
+        <rect x="338.8133" y="363.2312" width="118.87337" height="30" fill="white"/>
+        <text transform="translate(343.8133 368.2312)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">clones </tspan>
+          <tspan font-family="Courier New" font-size="16" fill="black" y="15">Sender</tspan>
+        </text>
+      </g>
+      <g id="Graphic_48">
+        <title>Sender</title>
+        <rect x="314.75" y="574.75" width="167" height="27" fill="white"/>
+        <rect x="314.75" y="574.75" width="167" height="27" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(319.75 579.25)" fill="black">
+          <tspan font-family="Courier New" font-size="16" fill="black" x="1.6875" y="13">channel_receiver</tspan>
+        </text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/community/planning/batch_submitter.md
+++ b/community/planning/batch_submitter.md
@@ -1,86 +1,121 @@
 <!--
-  Copyright 2021 Cargill Incorporated
+  Copyright 2022 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
   https://creativecommons.org/licenses/by/4.0/
 -->
 
 # Batch Submitter
 
-The batch submitter is a proposed component meant to monitor a database that
-holds batched transactions and send them to either a Hyperledger Sawtooth or
-Splinter network. Batch submitters are meant to be run as part of a cluster with
-other batch submitters in order to provide redundancy or reduce the time it
-takes for batches to be processed.
+## Overview
 
-## Batch Submission Algorithm
+The batch submitter component manages the submission of batches to the
+underlying distributed ledger technology (DLT). It is responsible for providing
+the submission queuer and DLT monitor with the information they need to
+accurately perform their own functions via updates to the batch database.
 
-A batch submitter sleeps for a configurable number of seconds before waking
-up and performing the following actions.
+### Why must the submitter exist?
 
-1. A submitter will acquire a lock from the database and fetch a configurable
-number of unclaimed batches (the `claim_limit`). An unclaimed batch is a batch
-whose submitted status is `false`, and its `claim_expires` time stamp is `NULL`
-or less than the `CURRENT_TIMESTAMP` of the database.
-```
-SELECT * FROM batches
-  WHERE submitted = false
-    AND (claim_expires is NULL
-      OR claim_expires < CURRENT_TIMESTAMP) LIMIT {claim_limit};
-```
+* We need to submit batches via individual http requests to the DLT
 
-The submitter will then update the `claim_expires` column to lay claim to
-each batch it retrieved for a configurable number of seconds. This step and
-the initial query for unclaimed batches are a part of the same database
-transaction.
+### How will the submitter be used?
 
-3. For each batch, the submitter will attempt to submit the batch. If the
-submitter receives an internal error or service unavailable error from the
-Splinter or Sawtooth network it will relinquish its claim to the batch, so
-that it or another submitter can retry sending the batch at a later interval.
-If The submitter receives a bad request error from the splinter network it will
-update the database by setting the submitted column to `true`, and updating the
-`submission_error` and `submission_error_message` columns describing why the
-batch was not submitted. If the batch was submitted successfully the submitted
-column is simply updated to `true`.
+* The submitter will poll the batch queue for batches to submit
+* The submitter will update the batch database via the store
 
-4. The submitter will go to sleep for a configurable number of seconds and then
-repeat the process.
+### What must the submitter do?
 
-## Database Schema
+* Submit batches in the order in which it receives them from the queuer
+* Update a batch's status via the store as soon as possible
+* Handle and report connection issues with the DLT or service
 
-```
-CREATE TABLE batches (
-    header_signature TEXT PRIMARY KEY,
-    data_change_id TEXT,
-    signer_public_key TEXT NOT NULL,
-    trace BOOLEAN NOT NULL,
-    serialized_batch TEXT NOT NULL,
-    submitted BOOLEAN NOT NULL,
-    submission_error VARCHAR(16),
-    submission_error_message TEXT,
-    dlt_status VARCHAR(16),
-    claim_expires TIMESTAMP,
-    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    service_id TEXT
-);
+### What must the submitters not do?
 
-CREATE TABLE transactions (
-    header_signature TEXT PRIMARY KEY,
-    batch_id TEXT NOT NULL,
-    family_name TEXT NOT NULL,
-    family_version TEXT NOT NULL,
-    signer_public_key TEXT NOT NULL,
-    FOREIGN KEY (batch_id) REFERENCES batches(header_signature) ON DELETE CASCADE
-);
+* Submit batches to the wrong service
+* Get hung up on a slow request
 
-CREATE TABLE transaction_receipts (
-    id BIGSERIAL PRIMARY KEY,
-    transaction_id TEXT UNIQUE,
-    result_valid BOOLEAN NOT NULL,
-    error_message TEXT,
-    error_data TEXT,
-    serialized_receipt TEXT NOT NULL,
-    external_status VARCHAR(16),
-    external_error_message TEXT
-);
-```
+### Design priorities
+
+1. Accuracy
+2. Stability
+3. Scalability
+4. High availability (HA)
+
+## Detail
+
+### Actor pattern
+
+The submitter design is based on an actor pattern. There is a main thread, which
+interfaces with the submission queuer and the stores, and the submission
+actor, which manages the actual submission of batches to the DLT.
+
+The actor pattern brings two key benefits to the submitter's design. First, it
+provides us with a great deal of flexibility in implementation. Second, the
+actor pattern translates across implementations, meaning we can solve for a
+variety of desired outcomes, such as low-dependency or HA requirements, using
+the same overall pattern.
+
+With the actor pattern, the submission actor is a resource that we deploy
+somewehere and with which we communicate via messages. If we want control over
+everything that's happening, or to minimize dependencies, those actors could be
+structs on threads. If we want to leverage an async runtime, the actors could
+be async tasks spawned in a tokio runtime. For HA, the actors may be containers
+in a cluster.
+
+### Implementation
+
+Since we want the submitter to be scalable, we leverage the async capablities
+of tokio, and the actor is an async runtime in which we spawn tasks.
+
+There are four subcomponents to the submitter: 
+
+* __the main thread__ - This has two responsibilities: 1) on initialization,
+  set up the receiver thread, async runtime, channels, and spawner thread, and
+  2) on an ongoing basis, poll the queuer for new batches, create new tasks,
+  and send them to the spawner thread.
+* __the receiver thread__ - This thread listens for submission responses from
+  submission tasks and updates the store accordingly.
+* __the spawner thread__ - This thread represents the tokio async runtime
+  (which is likely running on multiple os threads). It's role is to listen for
+  new task messages from the main thread and spawn new tasks accordingly.
+* __task handlers__ - These are tasks spawned in the tokio runtime that manage
+  the process of submitting a batch to a DLT. They submit the batches to the DLT
+  and send the submission response back to the main thread via an mpsc channel.
+
+![]({% link community/images/grid_batch_submitter.svg %} "Grid batch submitter diagram")
+
+#### Process
+
+1. The main thread polls the Submission queuer for the next thread and receives
+  a `BatchSubmission` (called "NewBatch" in the diagram for brevity).
+2. The main thread clones a `Sender` from a `std::sync::mpsc` channel that it
+  has dedicated for the listener thread to listen for submission responses from
+  tasks.
+3. The main thread packages the new `BatchSubmission` and `Sender` into a
+  `NewTask` message that it sends to the spawner thread via a capped
+  `tokio::sync::mpsc` channel.
+4. The spawner thread receives the `NewTask` message and spawns a new task in
+  tokio runtime, passing the `NewTask` message contents to the task.
+5. The task creates and runs a new `SubmissionController`, which submits the
+  new batch to the DLT.
+6. The task receives a response from the DLT and packages it into a
+  `SubmissionResponse` struct.
+7. The task uses the `Sender` that was bundled with the `BatchSubmission` to
+  send the `SubmissionResponse` to the listener thread.
+8. The listener thread receives the `SubmissionResponse` and updates the
+  batch's status in the batch database via the store accordingly.
+
+#### `SubmissionController` Detail
+
+As described above, the `SubmissionController` is the component that is 
+responsible for the submission of an individual batch. It has one subcomponent,
+the `SubmissionCommand`, that makes a single, non-blocking call (using 
+`reqwest`) to the DLT's batch submission endpoint. The `SubmissionController`
+creates a new `SubmissionCommand` and calls `execute()` on it.
+
+For most responses from the DLT, the `SubmissionController` will simply send
+the `SubmissionResponse` back to the `TaskHandler` (these will typically be 200
+responses). For 503 responses, the SubmissionController will retry the
+submission according to its retry logic by calling `execute()` on the
+`SubmissionCommand`. After a set number of retries, it will return a
+`SubmissionResponse` with a 503 status to the `TaskHandler`.
+


### PR DESCRIPTION
Updates the batch submitter design doc in the community planning section
with background and planning for the component.

The previous design doc was incompatible with the new, broad batch
submission and tracking design.

Signed-off-by: Chris Eckhardt <eckhardt@bitwise.io>