### PR TITLE
Fix links to Sawtooth documentation

### DIFF
--- a/_layouts/landing_page.html
+++ b/_layouts/landing_page.html
@@ -90,7 +90,7 @@
                 </p>
                 <p>
                     Hyperledger's
-                    <a href="https://sawtooth.hyperledger.org/docs/sabre/releases/latest/">
+                    <a href="https://sawtooth.hyperledger.org/docs/1.2/sabre/sabre_transaction_family.html">
                     Sawtooth Sabre</a> is the enabling technology behind
                     Grid's support for multiple distributed ledgers.
 

--- a/community/best_practices/feature_documentation.md
+++ b/community/best_practices/feature_documentation.md
@@ -63,8 +63,7 @@ format, and transaction types.
 *Examples*: <a href="/docs/{{ site.data.general.latest_version
 }}/grid_product_smart_contract_specification.html">
 Grid Product Smart Contract Specification</a>,
-[Sawtooth Supply Chain Transaction Family
-Specification](https://sawtooth.hyperledger.org/docs/supply-chain/nightly/master/family_specification.html)
+[Sawtooth Transaction Family Specifications](https://sawtooth.hyperledger.org/docs/1.2/transaction_family_specifications/)
 
 ### Database Tables Reference
 

--- a/community/planning/rest_api/openapi.yaml
+++ b/community/planning/rest_api/openapi.yaml
@@ -27,7 +27,7 @@ externalDocs:
   description: |
     For more information about how to create Sabre batches, please see the
     Sabre documentation.
-  url: https://sawtooth.hyperledger.org/docs/sabre/releases/latest/
+  url: https://sawtooth.hyperledger.org/docs/1.2/sabre/sabre_transaction_family.html
 paths:
   # Transactions
   /batch_statuses:

--- a/docs/0.1/glossary.md
+++ b/docs/0.1/glossary.md
@@ -26,7 +26,7 @@ batch
 Collection of related transactions that are handled as a group by the backend
 distributed ledger.
 (For more information, see the <a
-href="https://sawtooth.hyperledger.org/docs/core/releases/latest/glossary.html">
+href="https://sawtooth.hyperledger.org/faq/glossary.html">
 Sawtooth glossary</a>.)
 The Grid REST API provides the <code>batches</code> endpoint to submit batches
 of transactions and the <code>batch_statuses</code> endpoint to query the commit
@@ -92,7 +92,7 @@ Hyperledger Sawtooth
 <p class="glossary-definition">
 Backend distributed ledger system for executing transactions that provides a
 permissioned (private) network with dynamic consensus. For more information,
-see the <a href="https://sawtooth.hyperledger.org/docs/core/releases/latest/">
+see the <a href="https://sawtooth.hyperledger.org/docs/">
 Sawtooth documentation</a>.
 </p>
 
@@ -148,7 +148,7 @@ Sawtooth Sabre
 Smart-contract engine that executes smart contracts with WebAssembly (WASM).
 The rules for a smart contract are defined by a smart contract specification
 (formerly called a "transaction family"). For more information, see the
-<a href="https://sawtooth.hyperledger.org/docs/sabre/nightly/master/">
+<a href="https://sawtooth.hyperledger.org/docs/1.2/sabre/sabre_transaction_family.html">
 Sabre documentation</a>.
 </p>
 

--- a/docs/0.1/references/api/openapi.yaml
+++ b/docs/0.1/references/api/openapi.yaml
@@ -29,7 +29,7 @@ externalDocs:
   description: |
     For more information about how to create Sabre batches, please see the
     Sabre documentation.
-  url: https://sawtooth.hyperledger.org/docs/sabre/releases/latest/
+  url: https://sawtooth.hyperledger.org/docs/1.2/sabre/sabre_transaction_family.html
 paths:
   # Transactions
   /batches:
@@ -41,7 +41,7 @@ paths:
         description:
           For more information about the Batch data structure, see the Sawtooth
           architecture guide
-        url: https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/transactions_and_batches.html
+        url: https://sawtooth.hyperledger.org/docs/1.2/architecture/transactions_and_batches.html
       description: |
         This endpoint can be used to submit batches to the underlying
         distributed ledger. The operation called by this endpoint will depend on

--- a/docs/0.1/uploading_smart_contracts.md
+++ b/docs/0.1/uploading_smart_contracts.md
@@ -15,7 +15,7 @@ The examples in this procedure use the `sawtooth_xo` smart contract, which
 allows users to play a distributed game of tic-tac-toe, storing player data and
 game moves in shared state. For information about writing and compiling new
 smart contracts, see the [Sabre
-documentation](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/application_developer_guide.html).
+documentation](https://sawtooth.hyperledger.org/docs/1.2/sabre/application_developer_guide.html).
 
 ## Prerequisites
 
@@ -45,7 +45,7 @@ documentation](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/appli
 
 * A smart contract that has been compiled to WASM (as described in the
   [Sabre Application Developer's
-  Guide](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/application_developer_guide.html).
+  Guide](https://sawtooth.hyperledger.org/docs/1.2/sabre/application_developer_guide.html).
   This example uses the `sawtooth_xo` smart contract that is already packaged
   in a smart contract archive (scar) file.
 

--- a/docs/0.2/glossary.md
+++ b/docs/0.2/glossary.md
@@ -26,7 +26,7 @@ batch
 Collection of related transactions that are handled as a group by the backend
 distributed ledger.
 (For more information, see the <a
-href="https://sawtooth.hyperledger.org/docs/core/releases/latest/glossary.html">
+href="https://sawtooth.hyperledger.org/faq/glossary.html">
 Sawtooth glossary</a>.)
 The Grid REST API provides the <code>batches</code> endpoint to submit batches
 of transactions and the <code>batch_statuses</code> endpoint to query the commit
@@ -92,7 +92,7 @@ Hyperledger Sawtooth
 <p class="glossary-definition">
 Backend distributed ledger system for executing transactions that provides a
 permissioned (private) network with dynamic consensus. For more information,
-see the <a href="https://sawtooth.hyperledger.org/docs/core/releases/latest/">
+see the <a href="https://sawtooth.hyperledger.org/docs/">
 Sawtooth documentation</a>.
 </p>
 
@@ -148,7 +148,7 @@ Sawtooth Sabre
 Smart-contract engine that executes smart contracts with WebAssembly (WASM).
 The rules for a smart contract are defined by a smart contract specification
 (formerly called a "transaction family"). For more information, see the
-<a href="https://sawtooth.hyperledger.org/docs/sabre/nightly/master/">
+<a href="https://sawtooth.hyperledger.org/docs/1.2/sabre/sabre_transaction_family.html">
 Sabre documentation</a>.
 </p>
 

--- a/docs/0.2/references/api/openapi.yaml
+++ b/docs/0.2/references/api/openapi.yaml
@@ -29,7 +29,7 @@ externalDocs:
   description: |
     For more information about how to create Sabre batches, please see the
     Sabre documentation.
-  url: https://sawtooth.hyperledger.org/docs/sabre/releases/latest/
+  url: https://sawtooth.hyperledger.org/docs/1.2/sabre/sabre_transaction_family.html
 paths:
   # Transactions
   /batches:
@@ -41,7 +41,7 @@ paths:
         description:
           For more information about the Batch data structure, see the Sawtooth
           architecture guide
-        url: https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/transactions_and_batches.html
+        url: https://sawtooth.hyperledger.org/docs/1.2/architecture/transactions_and_batches.html
       description: |
         This endpoint can be used to submit batches to the underlying
         distributed ledger. The operation called by this endpoint will depend on

--- a/docs/0.2/uploading_smart_contracts.md
+++ b/docs/0.2/uploading_smart_contracts.md
@@ -15,7 +15,7 @@ The examples in this procedure use the `sawtooth_xo` smart contract, which
 allows users to play a distributed game of tic-tac-toe, storing player data and
 game moves in shared state. For information about writing and compiling new
 smart contracts, see the [Sabre
-documentation](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/application_developer_guide.html).
+documentation](https://sawtooth.hyperledger.org/docs/1.2/sabre/application_developer_guide.html).
 
 ## Prerequisites
 
@@ -45,7 +45,7 @@ documentation](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/appli
 
 * A smart contract that has been compiled to WASM (as described in the
   [Sabre Application Developer's
-  Guide](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/application_developer_guide.html).
+  Guide](https://sawtooth.hyperledger.org/docs/1.2/sabre/application_developer_guide.html).
   This example uses the `sawtooth_xo` smart contract that is already packaged
   in a smart contract archive (scar) file.
 

--- a/docs/0.3/glossary.md
+++ b/docs/0.3/glossary.md
@@ -26,7 +26,7 @@ batch
 Collection of related transactions that are handled as a group by the backend
 distributed ledger.
 (For more information, see the <a
-href="https://sawtooth.hyperledger.org/docs/core/releases/latest/glossary.html">
+href="https://sawtooth.hyperledger.org/faq/glossary.html">
 Sawtooth glossary</a>.)
 The Grid REST API provides the <code>batches</code> endpoint to submit batches
 of transactions and the <code>batch_statuses</code> endpoint to query the commit
@@ -99,7 +99,7 @@ Hyperledger Sawtooth
 <p class="glossary-definition">
 Backend distributed ledger system for executing transactions that provides a
 permissioned (private) network with dynamic consensus. For more information,
-see the <a href="https://sawtooth.hyperledger.org/docs/core/releases/latest/">
+see the <a href="https://sawtooth.hyperledger.org/docs/">
 Sawtooth documentation</a>.
 </p>
 
@@ -155,7 +155,7 @@ Sawtooth Sabre
 Smart-contract engine that executes smart contracts with WebAssembly (WASM).
 The rules for a smart contract are defined by a smart contract specification
 (formerly called a "transaction family"). For more information, see the
-<a href="https://sawtooth.hyperledger.org/docs/sabre/nightly/master/">
+<a href="https://sawtooth.hyperledger.org/docs/1.2/sabre/sabre_transaction_family.html">
 Sabre documentation</a>.
 </p>
 

--- a/docs/0.3/references/api/openapi.yaml
+++ b/docs/0.3/references/api/openapi.yaml
@@ -29,7 +29,7 @@ externalDocs:
   description: |
     For more information about how to create Sabre batches, please see the
     Sabre documentation.
-  url: https://sawtooth.hyperledger.org/docs/sabre/releases/latest/
+  url: https://sawtooth.hyperledger.org/docs/1.2/sabre/sabre_transaction_family.html
 paths:
   # Transactions
   /batches:
@@ -41,7 +41,7 @@ paths:
         description:
           For more information about the Batch data structure, see the Sawtooth
           architecture guide
-        url: https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/transactions_and_batches.html
+        url: https://sawtooth.hyperledger.org/docs/1.2/architecture/transactions_and_batches.html
       description: |
         This endpoint can be used to submit batches to the underlying
         distributed ledger. The operation called by this endpoint will depend on

--- a/docs/0.3/uploading_smart_contracts.md
+++ b/docs/0.3/uploading_smart_contracts.md
@@ -15,7 +15,7 @@ The examples in this procedure use the `sawtooth_xo` smart contract, which
 allows users to play a distributed game of tic-tac-toe, storing player data and
 game moves in shared state. For information about writing and compiling new
 smart contracts, see the [Sabre
-documentation](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/application_developer_guide.html).
+documentation](https://sawtooth.hyperledger.org/docs/1.2/sabre/application_developer_guide.html).
 
 ## Prerequisites
 
@@ -45,7 +45,7 @@ documentation](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/appli
 
 * A smart contract that has been compiled to WASM (as described in the
   [Sabre Application Developer's
-  Guide](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/application_developer_guide.html).
+  Guide](https://sawtooth.hyperledger.org/docs/1.2/sabre/application_developer_guide.html).
   This example uses the `sawtooth_xo` smart contract that is already packaged
   in a smart contract archive (scar) file.
 

--- a/docs/0.4/glossary.md
+++ b/docs/0.4/glossary.md
@@ -26,7 +26,7 @@ batch
 Collection of related transactions that are handled as a group by the backend
 distributed ledger.
 (For more information, see the <a
-href="https://sawtooth.hyperledger.org/docs/core/releases/latest/glossary.html">
+href="https://sawtooth.hyperledger.org/faq/glossary.html">
 Sawtooth glossary</a>.)
 The Grid REST API provides the <code>batches</code> endpoint to submit batches
 of transactions and the <code>batch_statuses</code> endpoint to query the commit
@@ -99,7 +99,7 @@ Hyperledger Sawtooth
 <p class="glossary-definition">
 Backend distributed ledger system for executing transactions that provides a
 permissioned (private) network with dynamic consensus. For more information,
-see the <a href="https://sawtooth.hyperledger.org/docs/core/releases/latest/">
+see the <a href="https://sawtooth.hyperledger.org/docs/">
 Sawtooth documentation</a>.
 </p>
 
@@ -155,7 +155,7 @@ Sawtooth Sabre
 Smart-contract engine that executes smart contracts with WebAssembly (WASM).
 The rules for a smart contract are defined by a smart contract specification
 (formerly called a "transaction family"). For more information, see the
-<a href="https://sawtooth.hyperledger.org/docs/sabre/nightly/master/">
+<a href="https://sawtooth.hyperledger.org/docs/1.2/sabre/sabre_transaction_family.html">
 Sabre documentation</a>.
 </p>
 

--- a/docs/0.4/references/api/openapi.yaml
+++ b/docs/0.4/references/api/openapi.yaml
@@ -29,7 +29,7 @@ externalDocs:
   description: |
     For more information about how to create Sabre batches, please see the
     Sabre documentation.
-  url: https://sawtooth.hyperledger.org/docs/sabre/releases/latest/
+  url: https://sawtooth.hyperledger.org/docs/1.2/sabre/sabre_transaction_family.html
 paths:
   # Transactions
   /batches:
@@ -41,7 +41,7 @@ paths:
         description:
           For more information about the Batch data structure, see the Sawtooth
           architecture guide
-        url: https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/transactions_and_batches.html
+        url: https://sawtooth.hyperledger.org/docs/1.2/architecture/transactions_and_batches.html
       description: |
         This endpoint can be used to submit batches to the underlying
         distributed ledger. The operation called by this endpoint will depend on

--- a/docs/0.4/uploading_smart_contracts.md
+++ b/docs/0.4/uploading_smart_contracts.md
@@ -15,7 +15,7 @@ The examples in this procedure use the `sawtooth_xo` smart contract, which
 allows users to play a distributed game of tic-tac-toe, storing player data and
 game moves in shared state. For information about writing and compiling new
 smart contracts, see the [Sabre
-documentation](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/application_developer_guide.html).
+documentation](https://sawtooth.hyperledger.org/docs/1.2/sabre/application_developer_guide.html).
 
 ## Prerequisites
 
@@ -45,7 +45,7 @@ documentation](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/appli
 
 * A smart contract that has been compiled to WASM (as described in the
   [Sabre Application Developer's
-  Guide](https://sawtooth.hyperledger.org/docs/sabre/releases/latest/application_developer_guide.html).
+  Guide](https://sawtooth.hyperledger.org/docs/1.2/sabre/application_developer_guide.html).
   This example uses the `sawtooth_xo` smart contract that is already packaged
   in a smart contract archive (scar) file.
 


### PR DESCRIPTION
The Sawtooth docs site recently underwent a reorganization. This PR fixes the existing links for the updated Sawtooth docs.