### PR TITLE
Update creating a circuit with Grid 0.3

### DIFF
--- a/docs/0.3/creating_splinter_circuits.md
+++ b/docs/0.3/creating_splinter_circuits.md
@@ -206,14 +206,14 @@ proposal, the circuit is created.
        alpha-node-000
            Service (scabbard): gsAA
              admin_keys:
-                 02c6fd62b0940512eb7e081facc39f4f7aba65ef4e6234d00b127b80c2f5c30e5b
+                 <gridd-alpha public key>
              peer_services:
                  gsBB
 
        beta-node-000
            Service (scabbard): gsBB
              admin_keys:
-                 02c6fd62b0940512eb7e081facc39f4f7aba65ef4e6234d00b127b80c2f5c30e5b
+                 <gridd-alpha public key>
              peer_services:
                  gsAA
    ```

--- a/docs/0.3/creating_splinter_circuits.md
+++ b/docs/0.3/creating_splinter_circuits.md
@@ -23,6 +23,9 @@ in the Splinter documentation.
   This procedure shows the private key files `/registry/alpha.priv` (on
   `alpha-node-000`) and `/registry/beta.priv` (on `beta-node-000`).
 
+  **Note**: If running Splinter 0.6, see the point below for how to authorize
+  circuit administrators on each node.
+
 * The URL of the Splinter REST API on the first node.  This procedure shows the
   URL `http://0.0.0.0:8085`.
 
@@ -30,6 +33,16 @@ in the Splinter documentation.
   belong to the circuit. This procedure shows
   `alpha-node-000::tcps://splinterd-alpha:8044` and
   `beta-node-000::tcps://splinterd-beta:8044`.
+
+* If running Splinter 0.6, authorized Splinter users. 0.6 requires authorization
+  for all interactions, which is not reflected in this tutorial as it is based
+  on the example docker-compose environment running Splinter 0.4. A user may be
+  authorized by adding their public key to Splinter's `allow_keys` file. This
+  example requires the public keys used as the splinter service's admin key,
+  the proposing node's `gridd.pub`, and as the circuit administrator, located in
+  the `/registry` directory, be added to the `allow_keys` file for Splinter 0.6
+  nodes. For more information on authorization in 0.6, see the [Splinter
+  documentation](https://splinter.dev/docs/0.6/howto/configuring_rest_api_authorization.html).
 
 For more information, see the [Splinter documentation: Creating a
 Circuit](https://www.splinter.dev/docs/0.4/tutorials/configuring_splinter_nodes.html#creating-a-circuit).
@@ -51,6 +64,20 @@ If the nodes are on separate physical systems, you must share node information
 and network endpoints with the other administrators. To use the Splinter
 registry to share node information, see the [Splinter
 documentation](https://www.splinter.dev/docs/0.4/concepts/splinter_registry.html).
+
+Grid 0.3 supports both Splinter versions 0.4 and 0.6. As this procedure assumes
+all nodes are running in docker containers based on the example Grid-on-Splinter
+compose file, the Splinter commands are specific to version 0.4.
+
+If your Splinter node is running 0.6, some commands have additional arguments
+that must be added, noted below the affected tutorial step.
+
+If either Splinter node is running 0.6, the commands for creating a circuit will
+change depending on the version of Splinter used by the proposer. Altered
+commands for creating a circuit between two Splinter nodes running either v0.4
+or v0.6 are noted below the tutorial steps. For more information on creating a
+circuit with version 0.6, see the [Splinter
+documentation](https://www.splinter.dev/docs/0.6/references/cli/splinter-circuit-propose.1.html).
 
 ## Procedure
 
@@ -99,6 +126,9 @@ proposal, the circuit is created.
    user that should sign the vote transaction. This example uses the private key
    in `/registry/alpha.priv`.
 
+   This command is valid if the proposing node (`splinterd-alpha` in this
+   example) is running Splinter version 0.4.
+
    ```
    root@splinterd-alpha:/# splinter circuit propose \
       --key /registry/alpha.priv \
@@ -123,6 +153,48 @@ proposal, the circuit is created.
    qualified service ID, which is required by `grid` commands for operations
    on the circuit.
 
+   **Note**: If both nodes are running Splinter 0.6, the circuit propose command
+   will change as follows:
+
+   ```
+   root@splinterd-alpha:/# splinter circuit propose \
+      --key /registry/alpha.priv \
+      --url http://splinterd-alpha:8085 \
+      --management grid \
+      --auth-type trust \
+      --node alpha-node-000::tcps://splinterd-alpha:8044 \
+      --node beta-node-000::tcps://splinterd-beta:8044 \
+      --service gsAA::alpha-node-000 \
+      --service gsBB::beta-node-000 \
+      --service-type *::scabbard \
+      --service-arg *::admin_keys=$(cat gridd.pub) \
+      --service-peer-group gsAA,gsBB
+   ```
+
+   **Note**: If the proposing node is running Splinter 0.6 and the receiving
+   node is on Splinter 0.4, the circuit propose command will change as follows:
+
+   ```
+   root@splinterd-alpha:/# splinter circuit propose \
+     --key /registry/alpha.priv \
+     --url http://splinterd-alpha:8085 \
+     --management grid \
+     --compat 0.4 \
+     --node alpha-node-000::tcps://splinterd-alpha:8044 \
+     --node beta-node-000::tcps://splinterd-beta:8044 \
+     --service gsAA::alpha-node-000 \
+     --service gsBB::beta-node-000 \
+     --service-type gsAA::scabbard \
+     --service-type gsBB::scabbard \
+     --service-peer-group gsAA,gsBB \
+     --service-arg gsAA::admin_keys="[\"$(cat gridd.pub)\"]" \
+     --service-arg gsBB::admin_keys="[\"$(cat gridd.pub)\"]"
+   ```
+
+   For information on each option in Splinter 0.6, see the
+   [splinter-circuit-propose(1)](https://www.splinter.dev/docs/0.6/references/cli/splinter-circuit-propose.1.html)
+   man page.
+
 1. Check the output to see the results of the transaction. If the proposal
    transaction succeeded, the output should resemble this example:
 
@@ -146,12 +218,26 @@ proposal, the circuit is created.
                  gsAA
    ```
 
+   **Note**: If running Splinter 0.6, this output may change slightly. The main
+   information should match the proposal, regardless.
+
 1. Verify the results by displaying the list of proposals.
 
    ```
    root@splinterd-alpha:/# splinter circuit proposals --url http://splinterd-alpha:8085
    ID            MANAGEMENT MEMBERS                      COMMENTS
    01234-ABCDE   grid       alpha-node-000;beta-node-000
+   ```
+
+   **Note**: If running Splinter 0.6, add the `--key` argument to this command,
+   pointing to the user's private key file.
+
+   ```
+   root@splinterd-alpha:/# splinter circuit proposals \
+      --url http://splinterd-alpha:8085 \
+      --key /registry/alpha.priv
+   ID          NAME MANAGEMENT MEMBERS                      COMMENTS PROPOSAL_TYPE
+   01234-ABCDE -    grid       alpha-node-000;beta-node-000 -        Create
    ```
 
 1. Set a `CIRCUIT_ID` environment variable based on the output of the
@@ -189,6 +275,42 @@ proposal, the circuit is created.
                   gsAA
    ```
 
+   **Note**: If running Splinter 0.6, add the `--key` argument to this command,
+   pointing to the user's private key file. The output will also differ slightly
+   from above.
+
+   ```
+   root@splinterd-alpha:/# splinter circuit show $CIRCUIT_ID \
+      --url http://splinterd-alpha:8085 \
+      --key /registry/alpha.priv
+   Proposal to create: 01234-ABCDE
+     Display Name: -
+     Circuit Status: Active
+     Schema Version: 2
+     Management Type: grid
+
+     alpha-node-000
+         Vote: ACCEPT (implied as requester):
+             <alpha-public-key>
+         Endpoints:
+             tcps://splinterd-alpha:8044
+         Service (scabbard): gsAA
+             admin_keys:
+                 <gridd-alpha public key>
+             peer_services:
+                 gsBB
+
+     beta-node-000
+         Vote: PENDING
+         Endpoints:
+             tcps://splinterd-beta:8044
+         Service (scabbard): gsBB
+             admin_keys:
+                 <gridd-alpha public key>
+             peer_services:
+                 gsAA
+   ```
+
 ### Connect to the Second Node
 
 A user on the other node (or nodes) must vote to accept or reject the circuit
@@ -215,6 +337,17 @@ proposal.
    root@splinterd-beta:/# splinter circuit proposals --url http://splinterd-beta:8085
    ID            MANAGEMENT MEMBERS                      COMMENTS
    01234-ABCDE   grid       alpha-node-000;beta-node-000
+   ```
+
+   **Note**: If running Splinter 0.6, add the `--key` argument to this command,
+   pointing to the user's private key file.
+
+   ```
+   root@splinterd-beta:/# splinter circuit proposals \
+      --url http://splinterd-beta:8085 \
+      --key /registry/beta.priv
+   ID          NAME MANAGEMENT MEMBERS                      COMMENTS PROPOSAL_TYPE
+   01234-ABCDE -    grid       alpha-node-000;beta-node-000 -        Create
    ```
 
 1. As on the first node, save the ID in the `CIRCUIT_ID` environment variable,
@@ -249,6 +382,41 @@ proposal.
                   gsAA
    ```
 
+   **Note**: If running Splinter 0.6, add the `key` argument to this command,
+   pointing to the user's private key file.
+
+   ```
+   root@splinterd-beta:/# splinter circuit show $CIRCUIT_ID \
+      --url http://splinterd-beta:8085 \
+      --key /registry/beta.priv
+   Proposal to create: 01234-ABCDE
+      Display Name: -
+      Circuit Status: Active
+      Schema Version: 2
+      Management Type: grid
+
+      alpha-node-000
+          Vote: ACCEPT (implied as requester):
+              <alpha-public-key>
+          Endpoints:
+              tcps://splinterd-alpha:8044
+          Service (scabbard): gsAA
+              admin_keys:
+                  <gridd-alpha public key>
+              peer_services:
+                  gsBB
+
+      beta-node-000
+          Vote: PENDING
+          Endpoints:
+              tcps://splinterd-beta:8044
+          Service (scabbard): gsBB
+              admin_keys:
+                  <gridd-alpha public key>
+              peer_services:
+                  gsAA
+   ```
+
 1. Vote to accept the proposal.
 
    For the `--key` option, specify the full path for the private key file of the
@@ -276,6 +444,17 @@ proposal.
    01234-ABCDE   grid       alpha-node-000;beta-node-000
    ```
 
+   **Note**: If running Splinter 0.6, add the `key` argument to this command,
+   pointing to the user's private key file.
+
+   ```
+   root@splinterd-beta:/# splinter circuit list \
+      --url http://splinterd-beta:8085 \
+      --key /registry/beta.priv
+   ID          NAME MANAGEMENT MEMBERS
+   01234-ABCDE -    grid       alpha-node-000;beta-node-000
+   ```
+
 1. Check the circuit status on the first node. The circuit information should be
    the same on both nodes.
 
@@ -285,13 +464,24 @@ proposal.
    01234-ABCDE   grid       alpha-node-000;beta-node-000
    ```
 
+   **Note**: If running Splinter 0.6, add the `key` argument to this command,
+   pointing to the user's private key file.
+
+   ```
+   root@splinterd-alpha:/# splinter circuit list \
+      --url http://splinterd-alpha:8085 \
+      --key /registry/alpha.priv
+   ID          NAME MANAGEMENT MEMBERS
+   01234-ABCDE -    grid       alpha-node-000;beta-node-000
+   ```
+
 1. You can display the circuit's details with the `splinter circuit show`
    command. This example uses the `CIRCUIT_ID` variable that was set in an
    earlier step.
 
    ```
    root@splinterd-alpha:/# splinter circuit show $CIRCUIT_ID --url http://splinterd-alpha:8085
-   Circuit: rXdGO-TWr40
+   Circuit: 01234-ABCDE
        Management Type: grid
 
        alpha-node-000
@@ -312,6 +502,38 @@ proposal.
    Now that the circuit has been accepted, note that the output starts with
    `Circuit:` instead of the `Proposal to create:` label that marks a proposed
    circuit (as shown in a previous step).
+
+   **Note**: If running Splinter 0.6, add the `key` argument to this command,
+   pointing to the user's private key file.
+
+   ```
+   root@splinterd-alpha:/# splinter circuit show $CIRCUIT_ID \
+      --url http://splinterd-alpha:8085 \
+      --key /registry/alpha.priv
+   Circuit: 01234-ABCDE
+       Display Name: -
+       Circuit Status: Active
+       Schema Version: 2
+       Management Type: grid
+
+       alpha-node-000
+           Endpoints:
+               tcps://splinterd-alpha:8044
+           Service (scabbard): gsAA
+             admin_keys:
+                 <gridd-alpha public key>
+             peer_services:
+                 gsBB
+
+       beta-node-000
+           Endpoints:
+               tcps://splinterd-beta:8044
+           Service (scabbard): gsBB
+             admin_keys:
+                 <gridd-alpha public key>
+             peer_services:
+                 gsAA
+   ```
 
 ### Determine the Service ID
 

--- a/docs/0.3/creating_splinter_circuits.md
+++ b/docs/0.3/creating_splinter_circuits.md
@@ -439,7 +439,7 @@ proposal.
    For example:
 
    ```
-   root@splinterd-beta:/# splinter circuit list --url http://splinterd-alpha:8085
+   root@splinterd-beta:/# splinter circuit list --url http://splinterd-beta:8085
    ID            MANAGEMENT MEMBERS
    01234-ABCDE   grid       alpha-node-000;beta-node-000
    ```


### PR DESCRIPTION
This change updates the main walkthrough for creating a splinter circuit
to include directions for when one or both of the nodes are running Splinter
0.6.

Signed-off-by: Shannyn Telander <telander@bitwise.io>