### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,5 +1,5 @@
 repository:
-  name: grid
+  name: grid-docs
   description: Grid provides reference implementations of supply-chain-centric
     items – data types, data models, smart contracts, and more – that are
     anchored on existing open standards and industry best practices.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,16 +4,8 @@
 | Name | GitHub |
 | --- | --- |
 | Andi Gunderson | agunde406 |
-| Anne Chenette | chenette |
-| Dan Middleton | dcmiddle |
-| Darian Plumb | dplumb94 |
-| Dave Cecchi | davececchi |
 | Davey Newhall | dnewh |
-| Eloá Franca Verona | eloaverona |
-| James Mitchell | jsmitchell |
 | Peter Schwarz | peterschwarz |
-| Richard Berg | rberg2 |
-| Ryan Banks | RyanLassigBanks |
 | Ryan Beck-Buysse | rbuysse |
 | Shannyn Telander | shannynalayna |
 | Shawn Amundson | vaporos |
@@ -21,4 +13,12 @@
 ### Retired Maintainers
 | Name | GitHub |
 | --- | --- |
+| Anne Chenette | chenette |
 | Boyd Johnson | boydjohnson |
+| Dan Middleton | dcmiddle |
+| Darian Plumb | dplumb94 |
+| Dave Cecchi | davececchi |
+| Eloá Franca Verona | eloaverona |
+| James Mitchell | jsmitchell |
+| Richard Berg | rberg2 |
+| Ryan Banks | RyanLassigBanks |


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>